### PR TITLE
Fix Windows pipe transport: I/O timeouts and full pipe paths

### DIFF
--- a/SshNet.Agent.Tests/PipeTransportTests.cs
+++ b/SshNet.Agent.Tests/PipeTransportTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class PipeTransportTests
+    {
+        private const byte Ssh2AgentIdentitiesAnswer = 12;
+
+        private static void SkipUnlessWindows()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Skip("named pipes are Windows only");
+        }
+
+        /// <summary>
+        /// SSH_AUTH_SOCK style configuration commonly holds the full pipe path.
+        /// It used to be routed to a unix domain socket connect (File.Exists
+        /// returns true for pipe paths), which failed.
+        /// </summary>
+        [Fact]
+        public void FullPipePath_Connects()
+        {
+            SkipUnlessWindows();
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(Wire.Cat(new[] { Ssh2AgentIdentitiesAnswer }, Wire.U32(0)));
+
+            var agent = new SshAgent(@"\\.\pipe\" + fake.SocketPath, null);
+
+            Assert.Empty(agent.RequestIdentities());
+        }
+
+        /// <summary>
+        /// Named pipes have no read timeout; an agent that accepts the request
+        /// but never answers (e.g. waiting on a confirmation dialog nobody sees)
+        /// used to block the caller forever.
+        /// </summary>
+        [Fact]
+        public void UnresponsiveAgent_TimesOutOnRead()
+        {
+            SkipUnlessWindows();
+            var pipeName = "sshnet-agent-silent-" + Guid.NewGuid().ToString("N");
+            // buffered, so the request can be written; the answer never comes
+            using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
+                PipeTransmissionMode.Byte, PipeOptions.Asynchronous, inBufferSize: 4096, outBufferSize: 4096);
+            _ = server.WaitForConnectionAsync();
+            var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
+
+            Assert.Throws<TimeoutException>(() => agent.RequestIdentities());
+        }
+
+        /// <summary>
+        /// Writes can stall as well: with no buffer space a pipe write blocks
+        /// until the other side reads.
+        /// </summary>
+        [Fact]
+        public void AgentThatStopsReading_TimesOutOnWrite()
+        {
+            SkipUnlessWindows();
+            var pipeName = "sshnet-agent-stalled-" + Guid.NewGuid().ToString("N");
+            // unbuffered and never read from, so any write blocks
+            using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
+                PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            _ = server.WaitForConnectionAsync();
+            var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
+
+            Assert.Throws<TimeoutException>(() => agent.RequestIdentities());
+        }
+    }
+}

--- a/SshNet.Agent/SshAgentSocketStream.cs
+++ b/SshNet.Agent/SshAgentSocketStream.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading.Tasks;
 #if NETSTANDARD2_1
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
@@ -10,8 +11,11 @@ namespace SshNet.Agent
 {
     internal class SshAgentSocketStream : Stream, IDisposable
     {
+        private const string PipePrefix = @"\\.\pipe\";
+
         private readonly NamedPipeClientStream? _pipe;
         private readonly Stream _stream;
+        private readonly TimeSpan _timeout;
 #if NETSTANDARD2_1
         private readonly Socket? _socket;
 #endif
@@ -23,7 +27,14 @@ namespace SshNet.Agent
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return _stream.Read(buffer, offset, count);
+            if (_pipe is null)
+                return _stream.Read(buffer, offset, count);
+
+            // named pipes have no read/write timeouts, so enforce them ourselves;
+            // without one a stalled agent blocks the caller forever
+            var read = _stream.ReadAsync(buffer, offset, count);
+            WaitWithTimeout(read);
+            return read.Result;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -38,7 +49,22 @@ namespace SshNet.Agent
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            _stream.Write(buffer, offset, count);
+            if (_pipe is null)
+            {
+                _stream.Write(buffer, offset, count);
+                return;
+            }
+
+            WaitWithTimeout(_stream.WriteAsync(buffer, offset, count));
+        }
+
+        private void WaitWithTimeout(Task task)
+        {
+            // the pending operation is left to be aborted by Dispose, which the
+            // owner runs when this exception unwinds its using statement
+            if (Task.WaitAny(new Task[] { task }, _timeout) == -1)
+                throw new TimeoutException($"The ssh-agent did not answer within {_timeout.TotalSeconds:0.#}s");
+            task.GetAwaiter().GetResult(); // surfaces a fault unwrapped
         }
 
         public override bool CanRead => _stream.CanRead;
@@ -53,8 +79,12 @@ namespace SshNet.Agent
 
         public SshAgentSocketStream(string socketPath, TimeSpan timeout)
         {
+            _timeout = timeout;
 #if NETSTANDARD2_1
-            if (File.Exists(socketPath) || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // everything on unix is a unix domain socket; on Windows only paths
+            // that exist as files are (e.g. WSL sockets), never pipe paths
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (!IsPipePath(socketPath) && File.Exists(socketPath)))
             {
                 var ep = new UnixDomainSocketEndPoint(socketPath);
                 _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
@@ -65,9 +95,23 @@ namespace SshNet.Agent
                 return;
             }
 #endif
-            _pipe = new NamedPipeClientStream(".", socketPath, PipeDirection.InOut);
+            _pipe = new NamedPipeClientStream(".", PipeName(socketPath), PipeDirection.InOut, PipeOptions.Asynchronous);
             _pipe.Connect(Convert.ToInt32(timeout.TotalMilliseconds));
             _stream = _pipe;
+        }
+
+        private static bool IsPipePath(string socketPath)
+        {
+            return socketPath.StartsWith(PipePrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// NamedPipeClientStream wants the bare pipe name, but SSH_AUTH_SOCK style
+        /// configuration commonly holds the full path, e.g. \\.\pipe\openssh-ssh-agent.
+        /// </summary>
+        private static string PipeName(string socketPath)
+        {
+            return IsPipePath(socketPath) ? socketPath.Substring(PipePrefix.Length) : socketPath;
         }
 
         #region IDisposable


### PR DESCRIPTION
## Summary

Fixes review findings 3 and 4 — both in the Windows named-pipe transport of `SshAgentSocketStream`.

- **I/O timeouts** (finding 3): named pipes have no read/write timeouts, so an agent that accepts the connection but stalls — e.g. waiting on a key-confirmation dialog nobody sees in a service session — blocked the caller **forever**; the configured timeout only applied to `Connect`. Pipe reads *and* writes now run as overlapped I/O and throw `TimeoutException` when the timeout elapses. (Writes matter too: a pipe write blocks when the peer stops draining its buffer — writing the timeout test surfaced exactly that hang first.)
- **Full pipe paths** (finding 4): `\\.\pipe\openssh-ssh-agent` — what `SSH_AUTH_SOCK`-style configuration commonly holds — was routed to a *unix domain socket* connect, because `File.Exists` returns true for pipe paths, and failed. The prefix is now recognized and stripped for the pipe connection; unix sockets are only used on Windows for paths that exist as real files (WSL-style sockets).

## Note for merging

The dispose-pattern region of `SshAgentSocketStream` is untouched here — that is fixed in `fix/agent-io-cleanup` (#17).

## Test plan

- [x] New Windows tests: connecting via the full pipe path works (fails on `main` with a socket error); a connected-but-silent agent times out on read; an agent that stops reading times out on write (both hang forever on `main`). Tests skip on non-Windows.
- [x] Full real-world suite still passes on this machine (OpenSSH agent + Dockerized sshd): 8 passed, 5 skipped (Pageant not installed)

