### PR TITLE
Clean up agent I/O: UTF-8 strings, correct dispose pattern, dead code

### DIFF
--- a/SshNet.Agent.Tests/StringEncodingTests.cs
+++ b/SshNet.Agent.Tests/StringEncodingTests.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    /// <summary>
+    /// Key comments must survive the round trip through the agent as UTF-8, the
+    /// encoding OpenSSH uses. The writer used to encode them as ASCII and the
+    /// reader decoded them with the platform default (ANSI on .NET Framework).
+    /// </summary>
+    public class StringEncodingTests
+    {
+        private const string Comment = "grüße from München";
+        private const byte Ssh2AgentIdentitiesAnswer = 12;
+        private const byte SshAgentSuccess = 6;
+
+        [Fact]
+        public void AddIdentity_WritesTheCommentAsUtf8()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            var keyFile = new PrivateKeyFile(TestKeys.PrivateKeyPath(TestKeys.Ed25519Puttygen));
+            ((KeyHostAlgorithm)keyFile.HostKeyAlgorithms.First()).Key.Comment = Comment;
+
+            fake.CreateClient().AddIdentity(keyFile);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(17, request.Byte()); // SSH2_AGENTC_ADD_IDENTITY
+            Assert.Equal("ssh-ed25519", request.Text());
+            request.Str(); // public key
+            request.Str(); // private key
+            Assert.Equal(Comment, request.Text());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void RequestIdentities_ReadsTheCommentAsUtf8()
+        {
+            using var fake = new FakeAgent();
+            var blob = TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen);
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(blob), Wire.Str(Comment)));
+
+            var identity = Assert.Single(fake.CreateClient().RequestIdentities());
+
+            Assert.Equal(Comment, ((KeyHostAlgorithm)identity.HostKeyAlgorithms.First()).Key.Comment);
+        }
+    }
+}

--- a/SshNet.Agent/AgentReader.cs
+++ b/SshNet.Agent/AgentReader.cs
@@ -1,24 +1,20 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
-using System.Numerics;
-using SshNet.Agent.Extensions;
 
 namespace SshNet.Agent
 {
     internal class AgentReader : BinaryReader
     {
-#if NETSTANDARD
-        public AgentReader(Stream input) : base(input, Encoding.Default, true)
-#else
-        public AgentReader(Stream input) : base(input, Encoding.Default)
-#endif
+        public AgentReader(Stream input) : base(input, Encoding.UTF8, leaveOpen: true)
         {
         }
 
         public override uint ReadUInt32()
         {
             var data = base.ReadBytes(4);
+            if (data.Length < 4)
+                throw new EndOfStreamException("The agent closed the connection mid-message");
             if (BitConverter.IsLittleEndian)
                 Array.Reverse(data);
             return BitConverter.ToUInt32(data, 0);
@@ -32,18 +28,7 @@ namespace SshNet.Agent
 
         public override string ReadString()
         {
-            return Encoding.Default.GetString(ReadStringAsBytes());
-        }
-
-        public BigInteger ReadBignum()
-        {
-            var data = ReadStringAsBytes();
-            return new BigInteger(data.Reverse());
-        }
-
-        public byte[] ReadBignum2()
-        {
-            return ReadStringAsBytes();
+            return Encoding.UTF8.GetString(ReadStringAsBytes());
         }
     }
 }

--- a/SshNet.Agent/AgentWriter.cs
+++ b/SshNet.Agent/AgentWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 
@@ -6,11 +6,7 @@ namespace SshNet.Agent
 {
     internal class AgentWriter : BinaryWriter
     {
-#if NETSTANDARD
-        public AgentWriter(Stream stream) : base(stream, Encoding.Default, true)
-#else
-        public AgentWriter(Stream stream) : base(stream, Encoding.Default)
-#endif
+        public AgentWriter(Stream stream) : base(stream, Encoding.UTF8, leaveOpen: true)
         {
         }
 
@@ -22,28 +18,19 @@ namespace SshNet.Agent
             base.Write(data);
         }
 
-        public void EncodeUInt(uint i)
-        {
-            var data = BitConverter.GetBytes(i);
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(data);
-            base.Write(data);
-        }
-
         public void EncodeBignum2(byte[] data)
         {
-            EncodeUInt((uint)data.Length);
-            base.Write(data);
+            EncodeString(data);
         }
 
         public void EncodeString(string str)
         {
-            EncodeString(Encoding.ASCII.GetBytes(str));
+            EncodeString(Encoding.UTF8.GetBytes(str));
         }
 
         public void EncodeString(byte[] str)
         {
-            EncodeUInt((uint)str.Length);
+            Write((uint)str.Length);
             base.Write(str);
         }
     }

--- a/SshNet.Agent/PageantSocketStream.cs
+++ b/SshNet.Agent/PageantSocketStream.cs
@@ -5,18 +5,19 @@ using System.Runtime.InteropServices;
 
 namespace SshNet.Agent
 {
-    public class PageantSocketStream : Stream, IDisposable
+    internal class PageantSocketStream : Stream
     {
         private const int AgentMaxMsglen = 8192;
         private const long AgentCopydataId = 0x804e50ba;
         private const int WmCopydata = 0x004A;
 
-        private readonly string _tempFile;
+        private readonly string _mapName;
         private readonly MemoryMappedFile _memoryMappedFile;
         private readonly Stream _stream;
         private readonly Copydatastruct _copyData;
         private readonly IntPtr _copyDataPtr;
 
+        [StructLayout(LayoutKind.Sequential)]
         private struct Copydatastruct {
             public IntPtr DwData;
             public int CbData;
@@ -66,8 +67,8 @@ namespace SshNet.Agent
 
         public PageantSocketStream()
         {
-            _tempFile = Path.GetRandomFileName();
-            _memoryMappedFile = MemoryMappedFile.CreateNew(_tempFile, AgentMaxMsglen);
+            _mapName = Path.GetRandomFileName();
+            _memoryMappedFile = MemoryMappedFile.CreateNew(_mapName, AgentMaxMsglen);
             _stream = _memoryMappedFile.CreateViewStream();
 
             _copyData = new Copydatastruct
@@ -75,8 +76,8 @@ namespace SshNet.Agent
                 DwData = IntPtr.Size == 4
                     ? new IntPtr(unchecked((int) AgentCopydataId))
                     : new IntPtr(AgentCopydataId),
-                CbData = _tempFile.Length + 1,
-                LpData = Marshal.StringToCoTaskMemAnsi(_tempFile)
+                CbData = _mapName.Length + 1,
+                LpData = Marshal.StringToHGlobalAnsi(_mapName)
             };
 
             _copyDataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(_copyData));
@@ -100,31 +101,20 @@ namespace SshNet.Agent
             return FindWindow("Pageant", "Pageant");
         }
 
-        #region IDisposable
         private bool _disposed;
-        public new void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
 
-        private new void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
-            if (_disposed)
-                return;
-
-            if (disposing)
+            if (!_disposed && disposing)
             {
                 _stream.Dispose();
                 _memoryMappedFile.Dispose();
                 Marshal.FreeHGlobal(_copyData.LpData);
                 Marshal.FreeHGlobal(_copyDataPtr);
-                if (File.Exists(_tempFile))
-                    File.Delete(_tempFile);
             }
 
             _disposed = true;
+            base.Dispose(disposing);
         }
-        #endregion
     }
 }

--- a/SshNet.Agent/SshAgentSocketStream.cs
+++ b/SshNet.Agent/SshAgentSocketStream.cs
@@ -114,20 +114,11 @@ namespace SshNet.Agent
             return IsPipePath(socketPath) ? socketPath.Substring(PipePrefix.Length) : socketPath;
         }
 
-        #region IDisposable
         private bool _disposed;
-        public new void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
 
-        private new void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
-            if (_disposed)
-                return;
-
-            if (disposing)
+            if (!_disposed && disposing)
             {
                 _stream.Dispose();
 #if NETSTANDARD2_1
@@ -137,7 +128,7 @@ namespace SshNet.Agent
             }
 
             _disposed = true;
+            base.Dispose(disposing);
         }
-        #endregion
     }
 }


### PR DESCRIPTION
## Summary

Bundles the reader/writer/stream findings from the code review (2, 5, 10, 12) — they touch the same few files, so one PR avoids conflicts between them.

- **UTF-8 strings** (bug fix): the writer encoded strings as ASCII — a key comment like `grüße` became `gr??e` — while the reader used `Encoding.Default`, which is ANSI on .NET Framework and UTF-8 on .NET, so the same bytes decoded differently per target. Both sides now use UTF-8, like OpenSSH.
- **Correct dispose pattern**: both socket streams hid `Stream.Dispose` with `new` members instead of overriding `Dispose(bool)`. Disposing through a `Stream`-typed reference was a silent no-op — cleanup only worked because the `using` statements happened to bind to the concrete types.
- **leaveOpen everywhere**: the `BinaryReader/Writer(Stream, Encoding, bool)` overload exists since .NET Framework 4.5, so the `#if NETSTANDARD` split was unnecessary; the net48 build previously let reader/writer dispose the shared socket stream.
- **Clearer EOF error**: a connection closed mid-message now throws `EndOfStreamException` instead of a cryptic `ArgumentException` from `BitConverter`.
- **Dead code and small fixes**: removed unused `ReadBignum`/`ReadBignum2`/`EncodeUInt`; removed the delete of a temp file that never existed (the field only names a memory-mapped file — renamed to `_mapName`); the ANSI string is now freed with the allocator that created it (`StringToCoTaskMemAnsi` was freed with `FreeHGlobal`); explicit `[StructLayout(LayoutKind.Sequential)]` on the `COPYDATASTRUCT`.
- **`PageantSocketStream` is now `internal`** ⚠️ *technically API-breaking*, but the type is unusable outside `Pageant.Send` (its sibling `SshAgentSocketStream` was always internal).

## Test plan

- [x] New tests: an `AddIdentity` request carries the comment `grüße from München` as UTF-8 bytes (fails on `main`), and an identities answer with a UTF-8 comment round-trips
- [x] Existing suite passes; full solution builds for all target frameworks

