### PR TITLE
Throw typed exceptions instead of bare System.Exception

### DIFF
--- a/SshNet.Agent.Tests/AgentErrorTests.cs
+++ b/SshNet.Agent.Tests/AgentErrorTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Renci.SshNet.Security.Cryptography;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class AgentErrorTests
+    {
+        private const byte Ssh2AgentIdentitiesAnswer = 12;
+
+        [Fact]
+        public void AddIdentity_WhenTheAgentRefuses_ThrowsSshAgentFailureException()
+        {
+            // an unconfigured FakeAgent answers everything with SSH_AGENT_FAILURE
+            using var fake = new FakeAgent();
+            var keyFile = new PrivateKeyFile(TestKeys.PrivateKeyPath(TestKeys.Ed25519Puttygen));
+
+            var exception = Assert.Throws<SshAgentFailureException>(() => fake.CreateClient().AddIdentity(keyFile));
+
+            Assert.IsAssignableFrom<SshAgentException>(exception);
+        }
+
+        [Fact]
+        public void Sign_WhenTheAgentRefuses_ThrowsSshAgentFailureException()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen)), Wire.Str("key")));
+            var identity = Assert.Single(fake.CreateClient().RequestIdentities());
+            var algorithm = (KeyHostAlgorithm)identity.HostKeyAlgorithms.First();
+
+            // the sign request is not answered with SSH2_AGENT_SIGN_RESPONSE
+            Assert.Throws<SshAgentFailureException>(() => algorithm.Sign(new byte[] { 1, 2, 3 }));
+        }
+
+        [Fact]
+        public void AddIdentity_WithAnUnsupportedKeyType_ThrowsNotSupportedException()
+        {
+            using var fake = new FakeAgent();
+
+            var exception = Assert.Throws<NotSupportedException>(
+                () => fake.CreateClient().AddIdentity(new UnsupportedKeySource()));
+
+            Assert.Contains("ssh-dss", exception.Message);
+            // the malformed message was never sent
+            Assert.True(fake.Requests.IsEmpty);
+        }
+
+        private sealed class StubSignature : DigitalSignature
+        {
+            public override bool Verify(byte[] input, byte[] signature) => false;
+
+            public override byte[] Sign(byte[] input) => Array.Empty<byte>();
+        }
+
+        private sealed class UnsupportedKey : Key
+        {
+            protected override DigitalSignature DigitalSignature { get; } = new StubSignature();
+
+            public override BigInteger[] Public => Array.Empty<BigInteger>();
+
+            public override int KeyLength => 0;
+
+            public override string ToString() => "ssh-dss";
+        }
+
+        private sealed class UnsupportedKeySource : IPrivateKeySource
+        {
+            private readonly Key _key = new UnsupportedKey();
+
+            public IReadOnlyCollection<HostAlgorithm> HostKeyAlgorithms =>
+                new HostAlgorithm[] { new KeyHostAlgorithm("ssh-dss", _key) };
+
+            public Key Key => _key;
+        }
+    }
+}

--- a/SshNet.Agent/AgentMessage/AddIdentity.cs
+++ b/SshNet.Agent/AgentMessage/AddIdentity.cs
@@ -53,6 +53,8 @@ namespace SshNet.Agent.AgentMessage
                     keyWriter.EncodeString(publicKey[1].ToByteArray().Reverse());
                     keyWriter.EncodeBignum2(ecdsa.PrivateKey.ToBigInteger2().ToByteArray().Reverse());
                     break;
+                default:
+                    throw new NotSupportedException($"Adding keys of type {key} is not supported");
             }
             // comment
             keyWriter.EncodeString(key.Comment ?? "");
@@ -68,7 +70,7 @@ namespace SshNet.Agent.AgentMessage
             _ = reader.ReadUInt32(); // msglen
             var answer = (AgentMessageType)reader.ReadByte();
             if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
-                throw new Exception($"Wrong Answer {answer}");
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH_AGENT_SUCCESS");
             return null;
         }
     }

--- a/SshNet.Agent/AgentMessage/RemoveIdentity.cs
+++ b/SshNet.Agent/AgentMessage/RemoveIdentity.cs
@@ -41,7 +41,7 @@ namespace SshNet.Agent.AgentMessage
             _ = reader.ReadUInt32(); // msglen
             var answer = (AgentMessageType)reader.ReadByte();
             if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
-                throw new Exception($"Wrong Answer {answer}");
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH_AGENT_SUCCESS");
             return null;
         }
     }

--- a/SshNet.Agent/AgentMessage/RequestIdentities.cs
+++ b/SshNet.Agent/AgentMessage/RequestIdentities.cs
@@ -26,7 +26,7 @@ namespace SshNet.Agent.AgentMessage
             _ = reader.ReadUInt32(); // msglen
             var answer = (AgentMessageType)reader.ReadByte();
             if (answer != AgentMessageType.SSH2_AGENT_IDENTITIES_ANSWER)
-                throw new Exception($"Wrong Answer {answer}");
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH2_AGENT_IDENTITIES_ANSWER");
 
             var keys = new List<SshAgentPrivateKey>();
             var numKeys = reader.ReadUInt32();

--- a/SshNet.Agent/AgentMessage/RequestSign.cs
+++ b/SshNet.Agent/AgentMessage/RequestSign.cs
@@ -36,7 +36,7 @@ namespace SshNet.Agent.AgentMessage
             _ = reader.ReadUInt32(); // msglen
             var answer = (AgentMessageType)reader.ReadByte();
             if (answer != AgentMessageType.SSH2_AGENT_SIGN_RESPONSE)
-                throw new Exception($"Wrong Answer {answer}");
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH2_AGENT_SIGN_RESPONSE");
 
             var signatureData = reader.ReadStringAsBytes();
             using var signatureStream = new MemoryStream(signatureData);

--- a/SshNet.Agent/PageantSocketStream.cs
+++ b/SshNet.Agent/PageantSocketStream.cs
@@ -87,11 +87,11 @@ namespace SshNet.Agent
         {
             var hWnd = PageantWindow();
             if (hWnd == IntPtr.Zero)
-                throw new Exception("Pageant Window not found");
+                throw new SshAgentException("Pageant window not found, is Pageant running?");
 
             var resultPtr = SendMessage(hWnd, WmCopydata, IntPtr.Zero, _copyDataPtr);
             if (resultPtr == IntPtr.Zero)
-                throw new Exception("Unable to send data to Pageant");
+                throw new SshAgentException("Pageant did not accept the request");
             Position = 0; // pageant overwrites, so reset the stream to zero
         }
 

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -68,7 +68,7 @@ namespace SshNet.Agent
         {
             var signature = Send(new RequestSign(key, data, flags));
             if (signature is null)
-                return Array.Empty<byte>();
+                throw new SshAgentException("The agent did not return a signature");
             return (byte[])signature;
         }
 

--- a/SshNet.Agent/SshAgentException.cs
+++ b/SshNet.Agent/SshAgentException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace SshNet.Agent
+{
+    /// <summary>Thrown when communication with the key agent fails.</summary>
+    public class SshAgentException : Exception
+    {
+        public SshAgentException(string message) : base(message)
+        {
+        }
+
+        public SshAgentException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Thrown when the agent does not answer a request with the expected message,
+    /// most commonly SSH_AGENT_FAILURE: the agent is locked, the user declined a
+    /// confirmation prompt, or the agent rejected the request.
+    /// </summary>
+    public class SshAgentFailureException : SshAgentException
+    {
+        public SshAgentFailureException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes review findings 6, 7 and 11 — error handling. The library threw bare `System.Exception` everywhere, so callers could not catch agent failures deliberately, and the messages (`Wrong Answer SSH_AGENT_FAILURE`) did not explain what actually happened.

- **`SshAgentException`** (public) is the base for everything that goes wrong while talking to the agent, including the Pageant window/send errors.
- **`SshAgentFailureException : SshAgentException`** signals an unexpected answer — most commonly `SSH_AGENT_FAILURE`: the agent is locked, the user declined a confirmation prompt, or the agent rejected the request.
- **`AddIdentity` rejects unsupported key types up front** with `NotSupportedException`. The switch had no `default` case, so it silently wrote a truncated message (key type + comment, no key material) that the agent answered with an uninterpretable failure.
- **`SshAgent.Sign` throws** instead of returning an empty signature, which would only have surfaced as a baffling auth failure on the server side.

The `Unsupported KeyType` throw in `RequestIdentities` is deliberately untouched here — PR `fix/skip-unsupported-identities` removes it entirely.

## Test plan

- [x] New tests: `AddIdentity` and sign requests answered with `SSH_AGENT_FAILURE` throw `SshAgentFailureException` (catchable as `SshAgentException`); adding an unsupported key type throws `NotSupportedException` **before** anything is sent to the agent
- [x] Full solution builds for all target frameworks

