### PR TITLE
Polish NuGet packaging and cap the SSH.NET dependency

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -44,4 +44,4 @@ jobs:
         # NuGet server uri hosting the packages, defaults to https://api.nuget.org
         NUGET_SOURCE: https://api.nuget.org
         # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-        INCLUDE_SYMBOLS: false
+        INCLUDE_SYMBOLS: true

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Agent</PackageId>
@@ -13,12 +13,30 @@
         <Copyright>Copyright (c) 2021 - 2025 Stefan Rinkes</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/darinkes/SshNet.Agent/</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Authors>darinkes</Authors>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Label="SourceLink and symbols">
+        <RepositoryUrl>https://github.com/darinkes/SshNet.Agent</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SSH.NET" Version="[2024.2.0,)" />
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SSH.NET" Version="[2024.2.0,2025.0)" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Fixes review findings 9 and 13 — packaging.

- **Cap SSH.NET at `[2024.2.0,2025.0)`**: this library derives from SSH.NET's key classes (`RsaKey`, `EcdsaKey`, `ED25519Key`) and uses `SshKeyData`, so a future SSH.NET major is likely to break it silently under the previous open-ended `[2024.2.0,)` range. Bumping the cap becomes a deliberate, tested step.
- **README on nuget.org** via `PackageReadmeFile`.
- **XML documentation files** are generated and packed (`CS1591` suppressed for now — most public members lack doc comments yet).
- **SourceLink**: repository metadata + `Microsoft.SourceLink.GitHub`, `PublishRepositoryUrl`, `EmbedUntrackedSources`, and `ContinuousIntegrationBuild` on GitHub Actions for deterministic builds, so consumers can step into the library.
- **Symbol packages**: `.snupkg` is produced and the NuGet workflow now pushes it (`INCLUDE_SYMBOLS: true`).
- Dropped the stray empty entry in the non-Windows `TargetFrameworks` list.

No version bump — the changes take effect with the next release the usual way.

## Test plan

- [x] `dotnet pack -c Release` verified: nupkg contains `README.md` + `SshNet.Agent.xml` for all three TFMs; nuspec shows `<readme>`, `<repository url=... commit=...>` and `SSH.NET [2024.2.0, 2025.0.0)`; `.snupkg` produced
- [x] Full solution builds for net48/netstandard2.0/netstandard2.1

