### PR TITLE
Support key constraints: lifetime and confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note: Only with netstandard 2.1 it contains support for Unix Domain Sockets to u
 
 - Auth
 - Adding Keys
+- Adding Keys with Constraints (lifetime, confirm)
 - Getting Keys
 - Removing Keys
 - Removing all Keys
@@ -65,6 +66,18 @@ var keys = agent.RequestIdentities();
 using var client = new SshClient("ssh.foo.com", "root", keys);
 client.Connect();
 Console.WriteLine(client.RunCommand("hostname").Result);
+```
+
+### Key Constraints
+
+Keys can be added with the constraints known from `ssh-add -t` and `ssh-add -c`:
+
+```csharp
+var agent = new SshAgent();
+
+// the agent removes the key after 10 minutes and asks for
+// confirmation on every use
+agent.AddIdentity(new PrivateKeyFile("test.key"), TimeSpan.FromMinutes(10), confirm: true);
 ```
 
 ## Resharper Warning

--- a/SshNet.Agent.Tests/ConstrainedAddTests.cs
+++ b/SshNet.Agent.Tests/ConstrainedAddTests.cs
@@ -1,0 +1,81 @@
+using System;
+using Renci.SshNet;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class ConstrainedAddTests
+    {
+        private const byte Ssh2AgentcAddIdentity = 17;
+        private const byte Ssh2AgentcAddIdConstrained = 25;
+        private const byte ConstrainLifetime = 1;
+        private const byte ConstrainConfirm = 2;
+        private const byte SshAgentSuccess = 6;
+
+        private static WireReader RecordAddIdentity(TimeSpan? lifetime, bool confirm)
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            var keyFile = new PrivateKeyFile(TestKeys.PrivateKeyPath(TestKeys.Ed25519Puttygen));
+
+            fake.CreateClient().AddIdentity(keyFile, lifetime, confirm);
+
+            return new WireReader(fake.SingleRequest());
+        }
+
+        private static WireReader SkipKeyAndComment(WireReader request)
+        {
+            request.Text(); // key type (ssh-ed25519)
+            request.Str(); // public key
+            request.Str(); // private key
+            request.Str(); // comment
+            return request;
+        }
+
+        [Fact]
+        public void Lifetime_SendsTheConstrainedMessageWithSeconds()
+        {
+            var request = RecordAddIdentity(TimeSpan.FromMinutes(10), confirm: false);
+
+            Assert.Equal(Ssh2AgentcAddIdConstrained, request.Byte());
+            SkipKeyAndComment(request);
+            Assert.Equal(ConstrainLifetime, request.Byte());
+            Assert.Equal(600u, request.U32());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void Confirm_SendsTheConstrainedMessage()
+        {
+            var request = RecordAddIdentity(lifetime: null, confirm: true);
+
+            Assert.Equal(Ssh2AgentcAddIdConstrained, request.Byte());
+            SkipKeyAndComment(request);
+            Assert.Equal(ConstrainConfirm, request.Byte());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void LifetimeAndConfirm_SendsBothConstraints()
+        {
+            var request = RecordAddIdentity(TimeSpan.FromSeconds(30), confirm: true);
+
+            Assert.Equal(Ssh2AgentcAddIdConstrained, request.Byte());
+            SkipKeyAndComment(request);
+            Assert.Equal(ConstrainLifetime, request.Byte());
+            Assert.Equal(30u, request.U32());
+            Assert.Equal(ConstrainConfirm, request.Byte());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void NoConstraints_StillSendsThePlainMessage()
+        {
+            var request = RecordAddIdentity(lifetime: null, confirm: false);
+
+            Assert.Equal(Ssh2AgentcAddIdentity, request.Byte());
+            SkipKeyAndComment(request);
+            Assert.True(request.AtEnd);
+        }
+    }
+}

--- a/SshNet.Agent.Tests/RealWorldTests.cs
+++ b/SshNet.Agent.Tests/RealWorldTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using Renci.SshNet;
 using Xunit;
 
@@ -45,6 +47,36 @@ namespace SshNet.Agent.Tests
             using var agent = TestAgent.Start(kind, TestKeys.Ed25519ZeroLead);
 
             Assert.Equal("ok", Login(agent.Identity(TestKeys.Ed25519ZeroLead)));
+        }
+
+        /// <summary>
+        /// A key added with a lifetime (ssh-add -t) disappears from the agent by
+        /// itself. Needs no SSH server. Skips when the agent refuses constrained
+        /// adds or does not enforce the lifetime, since support varies by agent.
+        /// </summary>
+        [Theory]
+        [InlineData(AgentKind.OpenSsh)]
+        [InlineData(AgentKind.Pageant)]
+        public void KeyWithLifetime_ExpiresFromTheAgent(AgentKind kind)
+        {
+            using var testAgent = TestAgent.Start(kind);
+            var agent = testAgent.Agent;
+
+            try
+            {
+                agent.AddIdentity(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen), TimeSpan.FromSeconds(2));
+            }
+            catch (Exception e) when (e.Message.Contains("SSH_AGENT_FAILURE"))
+            {
+                Assert.Skip("the agent does not support key constraints");
+            }
+            Assert.NotNull(TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen));
+
+            for (var i = 0; i < 50 && TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen) is not null; i++)
+                Thread.Sleep(200);
+
+            if (TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen) is not null)
+                Assert.Skip("the agent accepted the lifetime constraint but does not enforce it");
         }
 
         [Theory]

--- a/SshNet.Agent/AgentMessage/AddIdentity.cs
+++ b/SshNet.Agent/AgentMessage/AddIdentity.cs
@@ -9,11 +9,19 @@ namespace SshNet.Agent.AgentMessage
 {
     internal class AddIdentity : IAgentMessage
     {
-        private readonly IPrivateKeySource _keyFile;
+        // draft-miller-ssh-agent, "Key Constraints"
+        private const byte ConstrainLifetime = 1;
+        private const byte ConstrainConfirm = 2;
 
-        public AddIdentity(IPrivateKeySource keyFile)
+        private readonly IPrivateKeySource _keyFile;
+        private readonly TimeSpan? _lifetime;
+        private readonly bool _confirm;
+
+        public AddIdentity(IPrivateKeySource keyFile, TimeSpan? lifetime = null, bool confirm = false)
         {
             _keyFile = keyFile;
+            _lifetime = lifetime;
+            _confirm = confirm;
         }
 
         public void To(AgentWriter writer)
@@ -56,10 +64,23 @@ namespace SshNet.Agent.AgentMessage
             }
             // comment
             keyWriter.EncodeString(key.Comment ?? "");
+
+            var messageType = AgentMessageType.SSH2_AGENTC_ADD_IDENTITY;
+            if (_lifetime is not null || _confirm)
+            {
+                messageType = AgentMessageType.SSH2_AGENTC_ADD_ID_CONSTRAINED;
+                if (_lifetime is not null)
+                {
+                    keyWriter.Write(ConstrainLifetime);
+                    keyWriter.Write(Convert.ToUInt32(_lifetime.Value.TotalSeconds));
+                }
+                if (_confirm)
+                    keyWriter.Write(ConstrainConfirm);
+            }
             var keyData = keyStream.ToArray();
 
             writer.Write((uint)(1 + keyData.Length));
-            writer.Write((byte)AgentMessageType.SSH2_AGENTC_ADD_IDENTITY);
+            writer.Write((byte)messageType);
             writer.Write(keyData);
         }
 

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -64,6 +64,17 @@ namespace SshNet.Agent
             _ = Send(new AddIdentity(keyFile));
         }
 
+        /// <summary>
+        /// Adds the key with constraints, like ssh-add -t/-c: the agent deletes
+        /// the key again after <paramref name="lifetime"/>, and with
+        /// <paramref name="confirm"/> it asks the user for confirmation on every
+        /// use of the key.
+        /// </summary>
+        public void AddIdentity(IPrivateKeySource keyFile, TimeSpan? lifetime, bool confirm = false)
+        {
+            _ = Send(new AddIdentity(keyFile, lifetime, confirm));
+        }
+
         internal byte[] Sign(IAgentKey key, byte[] data, uint flags = 0)
         {
             var signature = Send(new RequestSign(key, data, flags));


### PR DESCRIPTION
## Summary

Key constraints as known from `ssh-add -t` and `ssh-add -c`, via a new overload:

```csharp
agent.AddIdentity(keyFile, TimeSpan.FromMinutes(10), confirm: true);
```

With constraints the key is sent as `SSH2_AGENTC_ADD_ID_CONSTRAINED` with `SSH_AGENT_CONSTRAIN_LIFETIME` (uint32 seconds) and/or `SSH_AGENT_CONSTRAIN_CONFIRM` appended after the comment, per draft-miller-ssh-agent. The existing `AddIdentity(keyFile)` is untouched, so nothing changes for existing callers (a new optional parameter on the existing method would have been binary-breaking).

## Test plan

- [x] Golden-byte tests: lifetime only, confirm only, both (order lifetime→confirm like OpenSSH), and no constraints still sends the plain `SSH2_AGENTC_ADD_IDENTITY`
- [x] Real-world test: a key added with a 2s lifetime disappears from a real agent by itself (needs no SSH server). Support varies by agent, so it skips when the agent refuses constrained adds — real Pageant does, verified locally — or accepts but does not enforce the lifetime; the wire encoding stays pinned by the golden-byte tests either way. The OpenSSH ssh-agent variant runs on CI.
- [x] Full solution builds for all target frameworks

