### PR TITLE
Support locking and unlocking the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var agent = new SshAgent { IncludeLegacySshRsa = true };
 - Getting Keys
 - Removing Keys
 - Removing all Keys
+- Locking and Unlocking the Agent
 
 ## Agent Protocol Documentation
 [draft-miller-ssh-agent-02](https://tools.ietf.org/html/draft-miller-ssh-agent-02)
@@ -90,6 +91,19 @@ var agent = new SshAgent();
 // the agent removes the key after 10 minutes and asks for
 // confirmation on every use
 agent.AddIdentity(new PrivateKeyFile("test.key"), TimeSpan.FromMinutes(10), confirm: true);
+```
+
+### Locking and Unlocking
+
+A locked agent hides its identities and refuses signing until it is unlocked
+again, like `ssh-add -x`/`ssh-add -X`:
+
+```csharp
+var agent = new SshAgent();
+
+agent.Lock("passphrase");
+// agent.RequestIdentities() is empty now
+agent.Unlock("passphrase");
 ```
 
 ## Resharper Warning

--- a/SshNet.Agent.Tests/LockUnlockTests.cs
+++ b/SshNet.Agent.Tests/LockUnlockTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class LockUnlockTests
+    {
+        private const byte SshAgentcLock = 22;
+        private const byte SshAgentcUnlock = 23;
+        private const byte SshAgentSuccess = 6;
+
+        [Fact]
+        public void Lock_SendsThePassphrase()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            fake.CreateClient().Lock("correct horse battery staple");
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcLock, request.Byte());
+            Assert.Equal("correct horse battery staple", request.Text());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void Unlock_SendsThePassphrase()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            fake.CreateClient().Unlock("correct horse battery staple");
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcUnlock, request.Byte());
+            Assert.Equal("correct horse battery staple", request.Text());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void Unlock_WithTheWrongPassphrase_Throws()
+        {
+            // an unconfigured FakeAgent answers with SSH_AGENT_FAILURE, like a
+            // real agent does on a wrong passphrase
+            using var fake = new FakeAgent();
+
+            Assert.ThrowsAny<Exception>(() => fake.CreateClient().Unlock("wrong"));
+        }
+    }
+}

--- a/SshNet.Agent.Tests/RealWorldTests.cs
+++ b/SshNet.Agent.Tests/RealWorldTests.cs
@@ -90,6 +90,44 @@ namespace SshNet.Agent.Tests
             Assert.Equal("ok", Login(agent.Identity(TestKeys.Rsa)));
         }
 
+        /// <summary>
+        /// A locked agent hides its identities until it is unlocked again
+        /// (ssh-add -x / -X). Needs no SSH server. Skips when the agent does not
+        /// support locking. The agent is always unlocked again, even on failure,
+        /// so a shared agent (e.g. the Windows service) is never left locked.
+        /// </summary>
+        [Theory]
+        [InlineData(AgentKind.OpenSsh)]
+        [InlineData(AgentKind.Pageant)]
+        public void LockedAgent_HidesIdentitiesUntilUnlocked(AgentKind kind)
+        {
+            using var testAgent = TestAgent.Start(kind, TestKeys.Ed25519Puttygen);
+            var agent = testAgent.Agent;
+            Assert.NotNull(TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen));
+
+            try
+            {
+                agent.Lock("correct horse battery staple");
+            }
+            catch (Exception e)
+            {
+                // Pageant answers SSH_AGENT_FAILURE, the Windows OpenSSH agent
+                // just closes the connection without answering
+                Assert.Skip($"the agent does not support locking ({e.Message})");
+            }
+
+            try
+            {
+                Assert.Null(TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen));
+            }
+            finally
+            {
+                agent.Unlock("correct horse battery staple");
+            }
+
+            Assert.NotNull(TestKeys.Find(agent.RequestIdentities(), TestKeys.Ed25519Puttygen));
+        }
+
         [Theory]
         [InlineData(AgentKind.OpenSsh)]
         [InlineData(AgentKind.Pageant)]

--- a/SshNet.Agent/AgentMessage/LockAgent.cs
+++ b/SshNet.Agent/AgentMessage/LockAgent.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+
+namespace SshNet.Agent.AgentMessage
+{
+    internal class LockAgent : IAgentMessage
+    {
+        private readonly bool _lock;
+        private readonly string _passphrase;
+
+        public LockAgent(bool @lock, string passphrase)
+        {
+            _lock = @lock;
+            _passphrase = passphrase;
+        }
+
+        public void To(AgentWriter writer)
+        {
+            using var lockStream = new MemoryStream();
+            using var lockWriter = new AgentWriter(lockStream);
+            lockWriter.EncodeString(_passphrase);
+            var lockData = lockStream.ToArray();
+
+            writer.Write((uint)(1 + lockData.Length));
+            writer.Write((byte)(_lock ? AgentMessageType.SSH_AGENTC_LOCK : AgentMessageType.SSH_AGENTC_UNLOCK));
+            writer.Write(lockData);
+        }
+
+        public object? From(AgentReader reader)
+        {
+            _ = reader.ReadUInt32(); // msglen
+            var answer = (AgentMessageType)reader.ReadByte();
+            if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
+                throw new Exception($"Wrong Answer {answer}");
+            return null;
+        }
+    }
+}

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -39,6 +39,21 @@ namespace SshNet.Agent
             return (SshAgentPrivateKey[])list;
         }
 
+        /// <summary>
+        /// Locks the agent with the passphrase. A locked agent hides its
+        /// identities and refuses signing until it is unlocked again.
+        /// </summary>
+        public void Lock(string passphrase)
+        {
+            _ = Send(new LockAgent(true, passphrase));
+        }
+
+        /// <summary>Unlocks an agent previously locked with <see cref="Lock"/>.</summary>
+        public void Unlock(string passphrase)
+        {
+            _ = Send(new LockAgent(false, passphrase));
+        }
+
         public void RemoveAllIdentities()
         {
             _ = Send(new RemoveIdentity());


### PR DESCRIPTION
## Summary

`SSH_AGENTC_LOCK` / `SSH_AGENTC_UNLOCK` (`ssh-add -x`/`-X`):

```csharp
agent.Lock("passphrase");
// agent.RequestIdentities() is empty now
agent.Unlock("passphrase");
```

A locked agent hides its identities and refuses signing until unlocked.

The new message class throws the same bare `Exception` style as the rest of `main` for consistency; if #18 (typed exceptions) lands, the one throw in `LockAgent.From` should switch to `SshAgentFailureException` — happy to follow up.

## Test plan

- [x] Golden-byte tests for both messages (type byte + passphrase string)
- [x] Wrong passphrase (agent answers `SSH_AGENT_FAILURE`) throws
- [x] Real-world test: a locked real agent hides its identities until unlocked again (needs no SSH server). The agent is always unlocked in a `finally`, so a shared agent (e.g. the Windows service) is never left locked, and the test skips when the agent does not support locking — real Pageant refuses it, verified locally. The OpenSSH ssh-agent variant runs on CI.
- [x] Full solution builds for all target frameworks

