### PR TITLE
Add an async API

### DIFF
--- a/SshNet.Agent.Tests/AsyncApiTests.cs
+++ b/SshNet.Agent.Tests/AsyncApiTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class AsyncApiTests
+    {
+        private const byte Ssh2AgentIdentitiesAnswer = 12;
+        private const byte Ssh2AgentcAddIdentity = 17;
+        private const byte SshAgentSuccess = 6;
+
+        [Fact]
+        public async Task RequestIdentitiesAsync_ReturnsTheIdentities()
+        {
+            using var fake = new FakeAgent();
+            var blob = TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen);
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(blob), Wire.Str("ed25519 key")));
+
+            var identities = await fake.CreateClient().RequestIdentitiesAsync(TestContext.Current.CancellationToken);
+
+            var identity = Assert.Single(identities);
+            var algorithm = (KeyHostAlgorithm)identity.HostKeyAlgorithms.First();
+            Assert.Equal(blob, algorithm.Data);
+            Assert.Equal("ed25519 key", algorithm.Key.Comment);
+        }
+
+        [Fact]
+        public async Task AddIdentityAsync_SendsTheSameMessageAsTheSyncApi()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            var keyFile = new PrivateKeyFile(TestKeys.PrivateKeyPath(TestKeys.Ed25519Puttygen));
+
+            await fake.CreateClient().AddIdentityAsync(keyFile, TestContext.Current.CancellationToken);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(Ssh2AgentcAddIdentity, request.Byte());
+            Assert.Equal("ssh-ed25519", request.Text());
+        }
+
+        [Fact]
+        public async Task RemoveAllIdentitiesAsync_Succeeds()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            await fake.CreateClient().RemoveAllIdentitiesAsync(TestContext.Current.CancellationToken);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(19, request.Byte()); // SSH2_AGENTC_REMOVE_ALL_IDENTITIES
+        }
+
+        [Fact]
+        public async Task UnresponsiveAgent_TimesOutAsync()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Skip("named pipes are Windows only");
+
+            var pipeName = "sshnet-agent-silent-" + Guid.NewGuid().ToString("N");
+            // buffered, so the request can be written; the answer never comes
+            using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
+                PipeTransmissionMode.Byte, PipeOptions.Asynchronous, inBufferSize: 4096, outBufferSize: 4096);
+            _ = server.WaitForConnectionAsync();
+            var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
+
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => agent.RequestIdentitiesAsync(TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task CanceledToken_CancelsTheRequest()
+        {
+            using var fake = new FakeAgent();
+            using var canceled = new CancellationTokenSource();
+            canceled.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => fake.CreateClient().RequestIdentitiesAsync(canceled.Token));
+        }
+    }
+}

--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Runtime.InteropServices;
 #endif
+using System.Threading;
+using System.Threading.Tasks;
 using SshNet.Agent.AgentMessage;
 
 namespace SshNet.Agent
@@ -27,6 +29,13 @@ namespace SshNet.Agent
             message.To(writer);
             socketStream.Send();
             return message.From(reader);
+        }
+
+        internal override Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)
+        {
+            // Pageant is driven by a window message, which has no asynchronous
+            // form; the memory-mapped hand-off completes synchronously anyway
+            return Task.FromResult(Send(message));
         }
     }
 }

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Renci.SshNet;
 using Renci.SshNet.Security;
 using SshNet.Agent.AgentMessage;
@@ -91,6 +94,96 @@ namespace SshNet.Agent
 
             message.To(writer);
             return message.From(reader);
+        }
+
+        /// <summary>Async variant of <see cref="RequestIdentities"/>.</summary>
+        public async Task<SshAgentPrivateKey[]> RequestIdentitiesAsync(CancellationToken cancellationToken = default)
+        {
+            var list = await SendAsync(new RequestIdentities(this), cancellationToken).ConfigureAwait(false);
+            if (list is null)
+                return new SshAgentPrivateKey[] {};
+            return (SshAgentPrivateKey[])list;
+        }
+
+        /// <summary>Async variant of <see cref="AddIdentity"/>.</summary>
+        public async Task AddIdentityAsync(IPrivateKeySource keyFile, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new AddIdentity(keyFile), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="RemoveIdentity"/>.</summary>
+        public async Task RemoveIdentityAsync(SshAgentPrivateKey sshAgentPrivateKey, CancellationToken cancellationToken = default)
+        {
+            if (((KeyHostAlgorithm)sshAgentPrivateKey.HostKeyAlgorithms.First()).Key is not IAgentKey agentKey)
+                throw new ArgumentException("Just AgentKeys can be removed");
+            _ = await SendAsync(new RemoveIdentity(agentKey), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="RemoveIdentities"/>.</summary>
+        public async Task RemoveIdentitiesAsync(IEnumerable<SshAgentPrivateKey> privateKeys, CancellationToken cancellationToken = default)
+        {
+            foreach (var privateKey in privateKeys)
+                await RemoveIdentityAsync(privateKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="RemoveAllIdentities"/>.</summary>
+        public async Task RemoveAllIdentitiesAsync(CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new RemoveIdentity(), cancellationToken).ConfigureAwait(false);
+        }
+
+        internal virtual async Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)
+        {
+            // messages serialize into memory, so only the transport needs to be
+            // asynchronous; the response is read completely before parsing
+            byte[] request;
+            using (var requestStream = new MemoryStream())
+            {
+                using (var writer = new AgentWriter(requestStream))
+                {
+                    message.To(writer);
+                }
+                request = requestStream.ToArray();
+            }
+
+            using var socketStream = await SshAgentSocketStream.ConnectAsync(_socketPath, _timeout, cancellationToken).ConfigureAwait(false);
+            await socketStream.WriteAsync(request, 0, request.Length, cancellationToken).ConfigureAwait(false);
+            var response = await ReadMessageAsync(socketStream, cancellationToken).ConfigureAwait(false);
+
+            using var responseStream = new MemoryStream(response);
+            using var reader = new AgentReader(responseStream);
+            return message.From(reader);
+        }
+
+        private const int MaxMessageLength = 256 * 1024; // OpenSSH AGENT_MAX_MSGLEN
+
+        /// <summary>
+        /// Reads one agent message (uint32 length + payload) and returns it
+        /// including the length prefix, which IAgentMessage.From expects to read.
+        /// </summary>
+        private static async Task<byte[]> ReadMessageAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            var header = new byte[4];
+            await ReadExactlyAsync(stream, header, 0, cancellationToken).ConfigureAwait(false);
+            var length = (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3];
+            if (length < 1 || length > MaxMessageLength)
+                throw new InvalidDataException($"Invalid agent message length {length}");
+
+            var message = new byte[4 + length];
+            Buffer.BlockCopy(header, 0, message, 0, 4);
+            await ReadExactlyAsync(stream, message, 4, cancellationToken).ConfigureAwait(false);
+            return message;
+        }
+
+        private static async Task ReadExactlyAsync(Stream stream, byte[] buffer, int offset, CancellationToken cancellationToken)
+        {
+            while (offset < buffer.Length)
+            {
+                var read = await stream.ReadAsync(buffer, offset, buffer.Length - offset, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    throw new EndOfStreamException("The agent closed the connection mid-message");
+                offset += read;
+            }
         }
     }
 }

--- a/SshNet.Agent/SshAgentSocketStream.cs
+++ b/SshNet.Agent/SshAgentSocketStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
 #if NETSTANDARD2_1
 using System.Runtime.InteropServices;
@@ -67,6 +68,33 @@ namespace SshNet.Agent
             task.GetAwaiter().GetResult(); // surfaces a fault unwrapped
         }
 
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = _stream.ReadAsync(buffer, offset, count, cancellationToken);
+            await WaitWithTimeoutAsync(read, cancellationToken).ConfigureAwait(false);
+            return read.Result;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await WaitWithTimeoutAsync(_stream.WriteAsync(buffer, offset, count, cancellationToken), cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WaitWithTimeoutAsync(Task task, CancellationToken cancellationToken)
+        {
+            using var stopDelay = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var winner = await Task.WhenAny(task, Task.Delay(_timeout, stopDelay.Token)).ConfigureAwait(false);
+            if (winner != task)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // the pending operation is aborted by Dispose, run by the owner
+                // when this exception unwinds its using statement
+                throw new TimeoutException($"The ssh-agent did not answer within {_timeout.TotalSeconds:0.#}s");
+            }
+            stopDelay.Cancel();
+            await task.ConfigureAwait(false);
+        }
+
         public override bool CanRead => _stream.CanRead;
         public override bool CanSeek => _stream.CanSeek;
         public override bool CanWrite => _stream.CanWrite;
@@ -81,23 +109,95 @@ namespace SshNet.Agent
         {
             _timeout = timeout;
 #if NETSTANDARD2_1
-            // everything on unix is a unix domain socket; on Windows only paths
-            // that exist as files are (e.g. WSL sockets), never pipe paths
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (!IsPipePath(socketPath) && File.Exists(socketPath)))
+            if (UseUnixSocket(socketPath))
             {
-                var ep = new UnixDomainSocketEndPoint(socketPath);
-                _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
-                _socket.ReceiveTimeout = Convert.ToInt32(timeout.TotalMilliseconds);
-                _socket.SendTimeout = Convert.ToInt32(timeout.TotalMilliseconds);
-                _socket.Connect(ep);
+                _socket = CreateUnixSocket(timeout);
+                _socket.Connect(new UnixDomainSocketEndPoint(socketPath));
                 _stream = new NetworkStream(_socket);
                 return;
             }
 #endif
-            _pipe = new NamedPipeClientStream(".", PipeName(socketPath), PipeDirection.InOut, PipeOptions.Asynchronous);
+            _pipe = CreatePipe(socketPath);
             _pipe.Connect(Convert.ToInt32(timeout.TotalMilliseconds));
             _stream = _pipe;
+        }
+
+#if NETSTANDARD2_1
+        private SshAgentSocketStream(Socket socket, TimeSpan timeout)
+        {
+            _socket = socket;
+            _stream = new NetworkStream(socket);
+            _timeout = timeout;
+        }
+#endif
+
+        private SshAgentSocketStream(NamedPipeClientStream pipe, TimeSpan timeout)
+        {
+            _pipe = pipe;
+            _stream = pipe;
+            _timeout = timeout;
+        }
+
+        public static async Task<SshAgentSocketStream> ConnectAsync(string socketPath, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+#if NETSTANDARD2_1
+            if (UseUnixSocket(socketPath))
+            {
+                var socket = CreateUnixSocket(timeout);
+                try
+                {
+                    var connect = socket.ConnectAsync(new UnixDomainSocketEndPoint(socketPath));
+                    if (await Task.WhenAny(connect, Task.Delay(timeout, cancellationToken)).ConfigureAwait(false) != connect)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        throw new TimeoutException($"Could not connect to the ssh-agent within {timeout.TotalSeconds:0.#}s");
+                    }
+                    await connect.ConfigureAwait(false);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+                return new SshAgentSocketStream(socket, timeout);
+            }
+#endif
+            var pipe = CreatePipe(socketPath);
+            try
+            {
+                await pipe.ConnectAsync(Convert.ToInt32(timeout.TotalMilliseconds), cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                pipe.Dispose();
+                throw;
+            }
+            return new SshAgentSocketStream(pipe, timeout);
+        }
+
+#if NETSTANDARD2_1
+        /// <summary>
+        /// Everything on unix is a unix domain socket; on Windows only paths
+        /// that exist as files are (e.g. WSL sockets), never pipe paths.
+        /// </summary>
+        private static bool UseUnixSocket(string socketPath)
+        {
+            return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                   (!IsPipePath(socketPath) && File.Exists(socketPath));
+        }
+
+        private static Socket CreateUnixSocket(TimeSpan timeout)
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+            socket.ReceiveTimeout = Convert.ToInt32(timeout.TotalMilliseconds);
+            socket.SendTimeout = Convert.ToInt32(timeout.TotalMilliseconds);
+            return socket;
+        }
+#endif
+
+        private static NamedPipeClientStream CreatePipe(string socketPath)
+        {
+            return new NamedPipeClientStream(".", PipeName(socketPath), PipeDirection.InOut, PipeOptions.Asynchronous);
         }
 
         private static bool IsPipePath(string socketPath)


### PR DESCRIPTION
## Summary

An async API for all agent management operations, each taking a `CancellationToken`:

- `RequestIdentitiesAsync`, `AddIdentityAsync`, `RemoveIdentityAsync`, `RemoveIdentitiesAsync`, `RemoveAllIdentitiesAsync`

Design notes:

- Agent messages serialize into memory, so only the **transport** is asynchronous: connect (`NamedPipeClientStream.ConnectAsync` / `Socket.ConnectAsync`), send, and receive all run as overlapped I/O with the configured timeout, using the same leave-the-abort-to-`Dispose` discipline as the sync path from #16. The message classes are untouched.
- The response length is validated against OpenSSH's `AGENT_MAX_MSGLEN` (256 KiB) before allocating, so a broken agent cannot make the client allocate 4 GB.
- `Pageant` overrides `SendAsync` to run synchronously: `WM_COPYDATA` has no async form and the memory-mapped hand-off completes synchronously anyway.
- **Signing stays sync by design**: SSH.NET calls it inside authentication through the synchronous `DigitalSignature` contract.

## Test plan

- [x] Async list/add/remove-all against the in-process fake agent, asserting the same wire bytes as the sync API
- [x] A connected-but-silent agent makes the async path throw `TimeoutException` (Windows)
- [x] A canceled token cancels the request with `OperationCanceledException`
- [x] Full suite on this branch: 13 passed (incl. real-world tests via Docker sshd), 5 skipped (Pageant not installed)

