### PR TITLE
Add a net8.0 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ SshNet.Agent
 * .NET 4.8
 * netstandard 2.0
 * netstandard 2.1
+* .NET 8.0
 
-Note: Only with netstandard 2.1 it contains support for Unix Domain Sockets to use ssh-agent on Linux.
+Note: Only the netstandard 2.1 and .NET 8.0 builds contain support for Unix Domain Sockets to use ssh-agent on Linux.
 
 ## Keys
 * ssh-ed25519

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Agent</PackageId>
@@ -19,6 +19,13 @@
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
+    </PropertyGroup>
+
+    <!-- The sources gate the unix socket support and platform guards on the
+         NETSTANDARD(2_1) symbols; net8.0 has all of those APIs, so define them
+         there instead of widening every #if. -->
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_1</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Label="SourceLink and symbols">


### PR DESCRIPTION
## Summary

Adds `net8.0` as a first-class target, so modern consumers stop falling back to netstandard2.1 — and the net8.0 test project now actually exercises the net8.0 build of the library.

One deliberate trick: the sources gate unix socket support and platform guards on the `NETSTANDARD(2_1)` symbols, and those `#if` lines are being reworked by the open I/O PRs (#16, #17). To avoid conflicting with them, this PR defines the symbols for net8.0 in the csproj instead of widening every `#if`. Once those PRs are merged, a mechanical follow-up can turn this into proper `NET` conditionals.

## Test plan

- [x] Full solution builds (net48, netstandard2.0, netstandard2.1, net8.0)
- [x] Full test suite runs against the net8.0 build of the library (real-world tests included)
- [x] `dotnet pack` verified: nupkg contains `lib/net8.0`

