### PR TITLE
Document the public API and make missing docs an error

### DIFF
--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -8,8 +8,13 @@ using SshNet.Agent.AgentMessage;
 
 namespace SshNet.Agent
 {
+    /// <summary>
+    /// Talks to PuTTY's Pageant over its WM_COPYDATA window message interface
+    /// instead of a socket. Windows only.
+    /// </summary>
     public class Pageant : SshAgent
     {
+        /// <summary>Creates the client; Pageant itself must already be running.</summary>
         public Pageant()
         {
 #if NETSTANDARD

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -11,6 +11,11 @@ using SshNet.Agent.Keys;
 
 namespace SshNet.Agent
 {
+    /// <summary>
+    /// Talks to an ssh-agent (OpenSSH or compatible) over a unix domain socket
+    /// or a Windows named pipe, so the identities it holds can be used with
+    /// SSH.NET. Signing happens inside the agent; private keys never leave it.
+    /// </summary>
     public class SshAgent
     {
         private readonly string _socketPath;
@@ -23,17 +28,30 @@ namespace SshNet.Agent
         /// </summary>
         public bool IncludeLegacySshRsa { get; set; }
 
+        /// <summary>
+        /// Uses the agent from the SSH_AUTH_SOCK environment variable, or the
+        /// default OpenSSH agent pipe on Windows when the variable is not set.
+        /// </summary>
         public SshAgent(TimeSpan? timeout = null)
             : this(Environment.GetEnvironmentVariable("SSH_AUTH_SOCK") ?? "openssh-ssh-agent", timeout)
         {
         }
 
+        /// <summary>
+        /// Uses the agent at the given unix domain socket path or Windows pipe
+        /// name (a full \\.\pipe\ path works as well). The timeout applies to
+        /// connecting and to each read and write; it defaults to 10 seconds.
+        /// </summary>
         public SshAgent(string socketPath, TimeSpan? timeout)
         {
             _socketPath = socketPath;
             _timeout = timeout ?? TimeSpan.FromSeconds(10);
         }
 
+        /// <summary>
+        /// Lists the identities the agent holds, usable as SSH.NET private key
+        /// sources. Key types this library cannot use (e.g. sk-*) are skipped.
+        /// </summary>
         public SshAgentPrivateKey[] RequestIdentities()
         {
             var list = Send(new RequestIdentities(this));
@@ -57,11 +75,13 @@ namespace SshNet.Agent
             _ = Send(new LockAgent(false, passphrase));
         }
 
+        /// <summary>Removes all identities from the agent.</summary>
         public void RemoveAllIdentities()
         {
             _ = Send(new RemoveIdentity());
         }
 
+        /// <summary>Removes the identities from the agent.</summary>
         public void RemoveIdentities(IEnumerable<SshAgentPrivateKey> privateKeys)
         {
             foreach (var privateKey in privateKeys)
@@ -70,6 +90,7 @@ namespace SshNet.Agent
             }
         }
 
+        /// <summary>Removes the identity from the agent.</summary>
         public void RemoveIdentity(SshAgentPrivateKey sshAgentPrivateKey)
         {
             // HostAlgorithm.Data is the blob the agent listed the identity
@@ -78,6 +99,10 @@ namespace SshNet.Agent
             _ = Send(new RemoveIdentity(sshAgentPrivateKey.HostKeyAlgorithms.First().Data));
         }
 
+        /// <summary>
+        /// Adds the key to the agent, together with its certificate when the
+        /// key file carries one.
+        /// </summary>
         public void AddIdentity(IPrivateKeySource keyFile)
         {
             _ = Send(new AddIdentity(keyFile));

--- a/SshNet.Agent/SshAgentException.cs
+++ b/SshNet.Agent/SshAgentException.cs
@@ -5,10 +5,12 @@ namespace SshNet.Agent
     /// <summary>Thrown when communication with the key agent fails.</summary>
     public class SshAgentException : Exception
     {
+        /// <summary>Creates the exception with a message describing the failure.</summary>
         public SshAgentException(string message) : base(message)
         {
         }
 
+        /// <summary>Creates the exception with a message and the causing exception.</summary>
         public SshAgentException(string message, Exception innerException) : base(message, innerException)
         {
         }
@@ -21,6 +23,7 @@ namespace SshNet.Agent
     /// </summary>
     public class SshAgentFailureException : SshAgentException
     {
+        /// <summary>Creates the exception with a message naming the unexpected answer.</summary>
         public SshAgentFailureException(string message) : base(message)
         {
         }

--- a/SshNet.Agent/SshAgentPrivateKey.cs
+++ b/SshNet.Agent/SshAgentPrivateKey.cs
@@ -7,14 +7,21 @@ using SshNet.Agent.Keys;
 
 namespace SshNet.Agent
 {
+    /// <summary>
+    /// An identity held by the agent, usable as an SSH.NET private key source:
+    /// signing is delegated to the agent, the private key never leaves it.
+    /// </summary>
     public class SshAgentPrivateKey : IPrivateKeySource
     {
         private readonly List<HostAlgorithm> _hostAlgorithms = new();
 
+        /// <summary>The host key algorithms this identity is offered with.</summary>
         public IReadOnlyCollection<HostAlgorithm> HostKeyAlgorithms => _hostAlgorithms;
 
+        /// <summary>The public key; for certificates the key embedded in the certificate.</summary>
         public Key Key { get; }
 
+        /// <summary>The identity of a plain key held by the agent.</summary>
         public SshAgentPrivateKey(SshAgent agent, Key key)
         {
             Key = key;
@@ -34,6 +41,10 @@ namespace SshNet.Agent
             _hostAlgorithms.Add(new KeyHostAlgorithm(key.ToString(), key));
         }
 
+        /// <summary>
+        /// The identity of an OpenSSH certificate held by the agent; the agent
+        /// signs with the private key matching <paramref name="certificateData"/>.
+        /// </summary>
         public SshAgentPrivateKey(SshAgent agent, Certificate certificate, byte[] certificateData)
         {
             Key = certificate.Key;

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -18,7 +18,8 @@
         <Authors>darinkes</Authors>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <!-- an undocumented public member is an error, so the API stays documented -->
+        <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     </PropertyGroup>
 
     <!-- The sources gate the unix socket support and platform guards on the


### PR DESCRIPTION
## Summary

Removes the `CS1591` suppression from the packaging PR: every public type and member now has an XML doc comment, and missing docs on the public API are promoted to a **build error** (`WarningsAsErrors` scoped to CS1591 only), so the API stays documented from here on.

Documented: `SshAgent` (class, both constructors, `RequestIdentities`, `AddIdentity`, `RemoveIdentity`/`RemoveIdentities`/`RemoveAllIdentities`), `Pageant` (class, constructor), `SshAgentPrivateKey` (class, both constructors, `Key`, `HostKeyAlgorithms`), and the exception constructors. Everything documented earlier (Lock/Unlock, async variants, constraints, `IncludeLegacySshRsa`) is untouched.

## Test plan

- [x] Full solution builds for all four target frameworks with CS1591 as error — zero occurrences
- [x] Full test suite passes (42 passed)
