### PR TITLE
Fix the remaining nullable warnings

### DIFF
--- a/SshNet.Agent.Tests/TestAgent.cs
+++ b/SshNet.Agent.Tests/TestAgent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -23,6 +24,7 @@ namespace SshNet.Agent.Tests
         /// Server). CI sets that variable so missing components cannot turn the
         /// pipeline silently green by skipping.
         /// </summary>
+        [DoesNotReturn]
         public static void Unavailable(string component, string reason)
         {
             var required = Environment.GetEnvironmentVariable("SSHNET_AGENT_TESTS_REQUIRED") ?? "";

--- a/SshNet.Agent/AgentMessage/AddIdentity.cs
+++ b/SshNet.Agent/AgentMessage/AddIdentity.cs
@@ -65,7 +65,8 @@ namespace SshNet.Agent.AgentMessage
 
         private static void WriteKey(AgentWriter keyWriter, Key key)
         {
-            keyWriter.EncodeString(key.ToString());
+            // ToString is the algorithm name for SSH.NET keys, never null
+            keyWriter.EncodeString(key.ToString()!);
             switch (key.ToString())
             {
                 case "ssh-ed25519":
@@ -89,7 +90,8 @@ namespace SshNet.Agent.AgentMessage
                     var publicKey = ecdsa.Public;
                     keyWriter.EncodeString(publicKey[0].ToByteArray().Reverse());
                     keyWriter.EncodeString(publicKey[1].ToByteArray().Reverse());
-                    keyWriter.EncodeBignum2(ecdsa.PrivateKey.ToBigInteger2().ToByteArray().Reverse());
+                    // a key loaded from a private key file always has the scalar
+                    keyWriter.EncodeBignum2(ecdsa.PrivateKey!.ToBigInteger2().ToByteArray().Reverse());
                     break;
                 default:
                     throw new NotSupportedException($"Adding keys of type {key} is not supported");
@@ -123,7 +125,8 @@ namespace SshNet.Agent.AgentMessage
                 // Fallthrough
                 case "ecdsa-sha2-nistp521":
                     var ecdsa = (EcdsaKey)key;
-                    keyWriter.EncodeBignum2(ecdsa.PrivateKey.ToBigInteger2().ToByteArray().Reverse());
+                    // a key loaded from a private key file always has the scalar
+                    keyWriter.EncodeBignum2(ecdsa.PrivateKey!.ToBigInteger2().ToByteArray().Reverse());
                     break;
                 default:
                     throw new NotSupportedException($"Adding certificates of type {key} is not supported");


### PR DESCRIPTION
## Summary

Fixes all remaining nullable-reference warnings (`CS8604`), which only surface in the net8.0 builds where the annotations are active:

- `AddIdentity`: `key.ToString()` is the algorithm name for SSH.NET keys and never null; `EcdsaKey.PrivateKey` is always present for keys loaded from a private key file. Both get the null-forgiving operator with a comment stating the invariant — no behavior change.
- `TestAgent`: `TestEnvironment.Unavailable` always throws (fail or skip), but the compiler could not see that through the wrapper; it is now annotated `[DoesNotReturn]`, which fixes the flow analysis at the call site checking `pageantExe` for null. (xunit v3's `Assert.Fail`/`Assert.Skip` are themselves annotated, so the attribute verifies cleanly.)

A full non-incremental build of all four target frameworks is now free of CS8xxx warnings. If you want to keep it that way, `<WarningsAsErrors>$(WarningsAsErrors);nullable</WarningsAsErrors>` would make regressions a build error — left out here to keep the change minimal.

## Test plan

- [x] `dotnet build --no-incremental` for all target frameworks: zero CS8xxx warnings
- [x] Full test suite passes (42 passed)
