### PR TITLE
Publish to NuGet via trusted publishing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -9,6 +9,12 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions:
+      # for the OIDC token behind NuGet trusted publishing
+      id-token: write
+      # the publish action pushes the version tag
+      contents: write
+
     steps:
     - uses: actions/checkout@v5
     - name: Setup .NET
@@ -21,6 +27,14 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    # Trusted publishing: exchange the workflow's OIDC token for a NuGet API
+    # key valid for 1 hour, matched against the trusted publishing policy on
+    # nuget.org (repository darinkes/SshNet.Agent, workflow nuget.yml).
+    - name: NuGet login (OIDC, temporary API key)
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      id: nuget_login
+      with:
+        user: ${{secrets.NUGET_USER}}
     - name: publish on version change
       id: publish_nuget
       uses: alirezanet/publish-nuget@e276c40afeb2a154046f0997820f2a9ea74832d9 # v3.1.0
@@ -29,18 +43,12 @@ jobs:
         PROJECT_FILE_PATH: SshNet.Agent/SshNet.Agent.csproj
         # NuGet package id, used for version detection & defaults to project name
         PACKAGE_NAME: SshNet.Agent
-        # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-        # VERSION_FILE_PATH: Directory.Build.props
-        # Regex pattern to extract version info in a capturing group
-        # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-        # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-        # VERSION_STATIC: 1.0.0
         # Flag to toggle git tagging, enabled by default
         TAG_COMMIT: true
         # Format of the git tag, [*] gets replaced with actual version
         TAG_FORMAT: "*"
-        # API key to authenticate with NuGet server
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+        # Temporary API key from the trusted publishing login above
+        NUGET_KEY: ${{steps.nuget_login.outputs.NUGET_API_KEY}}
         # NuGet server uri hosting the packages, defaults to https://api.nuget.org
         NUGET_SOURCE: https://api.nuget.org
         # Flag to toggle pushing symbols along with nuget package to the server, disabled by default


### PR DESCRIPTION
## Summary

Switches NuGet publishing to [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): the workflow exchanges its GitHub OIDC token for a NuGet API key that is valid for 1 hour and single-use, so there is no long-lived key to store, rotate, or leak.

- `NuGet/login` (pinned by commit, v1.2.0) obtains the temporary key; the existing publish-on-version-change action consumes it unchanged.
- The job gets an explicit `permissions` block: `id-token: write` for the OIDC token, `contents: write` because the publish action pushes the version tag.
- The nuget.org username comes from a `NUGET_USER` secret (profile name, not e-mail), as the docs recommend.

## ⚠️ Before merging

1. On nuget.org: username menu → **Trusted Publishing** → create a policy with Repository Owner `darinkes`, Repository `SshNet.Agent`, Workflow File `nuget.yml` (file name only), Environment empty.
2. In this repo's Actions secrets: add `NUGET_USER` = the nuget.org profile name.

Without the policy, the login step fails and the workflow goes red on the next push to `main`. The policy may show as "temporarily active (7 days)" until the first successful publish locks it to the repository ID.

## After the first successful publish

- Delete the `NUGET_API_KEY` secret from this repo and revoke the key on nuget.org.
- The same pattern works for every other SshNet.* repository: one policy per repo/workflow — a policy covers **all packages of the owner**, so no per-package API key patterns are needed anymore.

## Test plan

- [x] Workflow YAML parses (actionlint-equivalent structure check via GitHub on PR)
- [ ] First real publish after the version bump confirms the token exchange (cannot be tested without a policy + version change)
