### PR TITLE
Prepare the 2024.2.0.4-beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ var agent = new SshAgent { IncludeLegacySshRsa = true };
 - Removing Keys
 - Removing all Keys
 - Locking and Unlocking the Agent
+- Async API
 
 ## Agent Protocol Documentation
 [draft-miller-ssh-agent-02](https://tools.ietf.org/html/draft-miller-ssh-agent-02)
@@ -82,6 +83,42 @@ using var client = new SshClient("ssh.foo.com", "root", keys);
 client.Connect();
 Console.WriteLine(client.RunCommand("hostname").Result);
 ```
+
+### OpenSSH Certificates
+
+Certificate identities held by the agent (`*-cert-v01@openssh.com`) are offered
+to the server automatically; the agent signs with the matching private key. To
+add a key together with its certificate, load the certificate alongside the
+private key:
+
+```csharp
+var agent = new SshAgent();
+
+// test.key + the certificate signed by your CA (test-cert.pub)
+agent.AddIdentity(new PrivateKeyFile("test.key", null, "test-cert.pub"));
+
+var keys = agent.RequestIdentities();
+
+// works against servers that trust the CA (TrustedUserCAKeys)
+using var client = new SshClient("ssh.foo.com", "root", keys);
+client.Connect();
+```
+
+### Async
+
+All agent operations are also available asynchronously and take an optional
+`CancellationToken`:
+
+```csharp
+var agent = new SshAgent();
+
+await agent.AddIdentityAsync(new PrivateKeyFile("test.key"), cancellationToken);
+var keys = await agent.RequestIdentitiesAsync(cancellationToken);
+await agent.RemoveAllIdentitiesAsync(cancellationToken);
+```
+
+Note: Signing during authentication stays synchronous, since SSH.NET calls it
+through its synchronous `DigitalSignature` contract.
 
 ### Key Constraints
 

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -146,7 +146,7 @@ namespace SshNet.Agent
             return (SshAgentPrivateKey[])list;
         }
 
-        /// <summary>Async variant of <see cref="AddIdentity"/>.</summary>
+        /// <summary>Async variant of <see cref="AddIdentity(IPrivateKeySource)"/>.</summary>
         public async Task AddIdentityAsync(IPrivateKeySource keyFile, CancellationToken cancellationToken = default)
         {
             _ = await SendAsync(new AddIdentity(keyFile), cancellationToken).ConfigureAwait(false);

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -5,12 +5,12 @@
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Agent</PackageId>
-        <Version>2024.2.0.3-beta</Version>
+        <Version>2024.2.0.4-beta</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to authenticate via OpenSSH Agent and PuTTY Pageant</Description>
         <PackageReleaseNotes>https://github.com/darinkes/SshNet.Agent/releases/tag/$(PackageVersion)</PackageReleaseNotes>
-        <Copyright>Copyright (c) 2021 - 2025 Stefan Rinkes</Copyright>
+        <Copyright>Copyright (c) 2021 - 2026 Stefan Rinkes</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/darinkes/SshNet.Agent/</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -44,7 +44,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SSH.NET" Version="[2024.2.0,2025.0)" />
+        <PackageReference Include="SSH.NET" Version="[2024.2.0,2026.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Release preparation for **2024.2.0.4-beta**: version bump (merging this triggers the publish via trusted publishing and tags the commit), README sections for the async API and OpenSSH certificates, and the copyright year.

After merging, please create a GitHub release for the `2024.2.0.4-beta` tag — the package's release-notes link points there. Suggested notes below, ready to paste:

---

## SshNet.Agent 2024.2.0.4-beta

### ⚠️ Breaking changes

- Errors while talking to the agent now throw `SshAgentException` / `SshAgentFailureException` instead of bare `System.Exception`; adding an unsupported key type throws `NotSupportedException` up front.
- RSA identities are offered as `rsa-sha2-512`/`rsa-sha2-256` (RFC 8332). The legacy SHA-1 `ssh-rsa` is only offered with the new `IncludeLegacySshRsa` opt-in — this fixes "Too many authentication failures" with multiple RSA keys (#13) and works with OpenSSH 8.8+, which rejects ssh-rsa signatures.
- `RequestIdentities()` skips key types this library cannot use (e.g. `sk-*` FIDO keys) instead of failing the whole listing.
- `PageantSocketStream` is now internal.
- The SSH.NET dependency now declares the range `[2024.2.0, 2026.0)`. Compatibility with SSH.NET 2025.1.0 is verified: the library compiles against it on all four target frameworks and the full test suite passes with it at runtime (which also resolves the NU1608 warning the test build got from Testcontainers requiring SSH.NET 2025.1.0).

### New features

- **OpenSSH certificates**: certificate identities held by the agent (`*-cert-v01@openssh.com`) authenticate against servers that trust the CA, and `AddIdentity` adds key+certificate pairs (`PrivateKeyFile` with a certificate).
- **Key constraints**: `AddIdentity(keyFile, lifetime, confirm)` like `ssh-add -t`/`-c`.
- **Lock/Unlock**: `agent.Lock(passphrase)` / `agent.Unlock(passphrase)` like `ssh-add -x`/`-X`.
- **Async API**: `RequestIdentitiesAsync`, `AddIdentityAsync`, `RemoveIdentityAsync`, `RemoveIdentitiesAsync`, `RemoveAllIdentitiesAsync`, all taking a `CancellationToken`.
- **net8.0 target** in addition to net48/netstandard2.0/netstandard2.1.

### Fixes

- Windows named pipes: reads and writes now honor the configured timeout — a stalled agent no longer blocks the caller forever — and the full `\\.\pipe\openssh-ssh-agent` path is accepted.
- Key comments are encoded and decoded as UTF-8 on every framework.
- Correct `Stream.Dispose` pattern in the transport streams; the connection is reliably closed.
- Clear `EndOfStreamException` when the agent closes the connection mid-message.

### Packaging

- README and XML documentation ship with the package; missing docs on the public API are a build error.
- SourceLink with deterministic CI builds and snupkg symbol packages — consumers can step into the library.
- Publishing switched to NuGet trusted publishing (no stored API key).

### Tests

- Protocol-level golden-byte tests against an in-process fake agent run on every platform without prerequisites.
- Real-world tests cover OpenSSH ssh-agent and PuTTY Pageant against a real sshd, including certificate authentication against a CA-trusting server (`TrustedUserCAKeys`).

---

## Test plan

- [x] `dotnet pack`: nupkg + snupkg produced as `2024.2.0.4-beta`, copyright, release-notes URL and the `SSH.NET [2024.2.0, 2026.0.0)` dependency range correct
- [x] Library additionally compiled against SSH.NET `[2025.1.0]` exactly: no errors on any target framework, full suite passes
- [x] Fresh restore + non-incremental build: no NU1608, no CS0419 (ambiguous `AddIdentity` cref fixed), test suite passes (42 passed)
