### PR TITLE
Pass the test cancellation token to WaitForConnectionAsync

### DIFF
--- a/SshNet.Agent.Tests/AsyncApiTests.cs
+++ b/SshNet.Agent.Tests/AsyncApiTests.cs
@@ -97,7 +97,7 @@ namespace SshNet.Agent.Tests
             // buffered, so the request can be written; the answer never comes
             using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
                 PipeTransmissionMode.Byte, PipeOptions.Asynchronous, inBufferSize: 4096, outBufferSize: 4096);
-            _ = server.WaitForConnectionAsync();
+            _ = server.WaitForConnectionAsync(TestContext.Current.CancellationToken);
             var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
 
             await Assert.ThrowsAsync<TimeoutException>(

--- a/SshNet.Agent.Tests/PipeTransportTests.cs
+++ b/SshNet.Agent.Tests/PipeTransportTests.cs
@@ -45,7 +45,7 @@ namespace SshNet.Agent.Tests
             // buffered, so the request can be written; the answer never comes
             using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
                 PipeTransmissionMode.Byte, PipeOptions.Asynchronous, inBufferSize: 4096, outBufferSize: 4096);
-            _ = server.WaitForConnectionAsync();
+            _ = server.WaitForConnectionAsync(TestContext.Current.CancellationToken);
             var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
 
             Assert.Throws<TimeoutException>(() => agent.RequestIdentities());
@@ -63,7 +63,7 @@ namespace SshNet.Agent.Tests
             // unbuffered and never read from, so any write blocks
             using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
                 PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-            _ = server.WaitForConnectionAsync();
+            _ = server.WaitForConnectionAsync(TestContext.Current.CancellationToken);
             var agent = new SshAgent(pipeName, TimeSpan.FromMilliseconds(500));
 
             Assert.Throws<TimeoutException>(() => agent.RequestIdentities());


### PR DESCRIPTION
## Summary

Fixes the three `xUnit1051` warnings that showed up in the release build log: the silent named-pipe servers in `AsyncApiTests` and `PipeTransportTests` waited for connections without observing the test cancellation token. They now pass `TestContext.Current.CancellationToken`, so a cancelled test run does not leave pending connection waits behind.

The deliberately pre-canceled token in `CanceledToken_CancelsTheRequest` stays as is — that token is the point of the test.

## Test plan

- [x] Non-incremental build of the test project: zero xUnit1051 warnings
- [x] Full test suite passes (42 passed)