### PR TITLE
Throw the typed exception from LockAgent

### DIFF
--- a/SshNet.Agent.Tests/LockUnlockTests.cs
+++ b/SshNet.Agent.Tests/LockUnlockTests.cs
@@ -45,7 +45,7 @@ namespace SshNet.Agent.Tests
             // real agent does on a wrong passphrase
             using var fake = new FakeAgent();
 
-            Assert.ThrowsAny<Exception>(() => fake.CreateClient().Unlock("wrong"));
+            Assert.Throws<SshAgentFailureException>(() => fake.CreateClient().Unlock("wrong"));
         }
     }
 }

--- a/SshNet.Agent.Tests/RealWorldTests.cs
+++ b/SshNet.Agent.Tests/RealWorldTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using Renci.SshNet;
 using Xunit;
@@ -66,7 +67,7 @@ namespace SshNet.Agent.Tests
             {
                 agent.AddIdentity(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen), TimeSpan.FromSeconds(2));
             }
-            catch (Exception e) when (e.Message.Contains("SSH_AGENT_FAILURE"))
+            catch (SshAgentFailureException)
             {
                 Assert.Skip("the agent does not support key constraints");
             }
@@ -109,7 +110,7 @@ namespace SshNet.Agent.Tests
             {
                 agent.Lock("correct horse battery staple");
             }
-            catch (Exception e)
+            catch (Exception e) when (e is SshAgentFailureException or EndOfStreamException)
             {
                 // Pageant answers SSH_AGENT_FAILURE, the Windows OpenSSH agent
                 // just closes the connection without answering

--- a/SshNet.Agent/AgentMessage/LockAgent.cs
+++ b/SshNet.Agent/AgentMessage/LockAgent.cs
@@ -31,7 +31,7 @@ namespace SshNet.Agent.AgentMessage
             _ = reader.ReadUInt32(); // msglen
             var answer = (AgentMessageType)reader.ReadByte();
             if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
-                throw new Exception($"Wrong Answer {answer}");
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH_AGENT_SUCCESS");
             return null;
         }
     }


### PR DESCRIPTION
## Summary

Follow-up flagged in #23: `LockAgent.From` was written in the pre-#18 style and still threw bare `System.Exception`. It now throws `SshAgentFailureException` like every other agent message.

The tests get more precise with it: the wrong-passphrase unit test asserts the exact type, the lifetime real-world test catches `SshAgentFailureException` instead of matching message text, and the lock real-world test narrows its skip to `SshAgentFailureException or EndOfStreamException` (Pageant refuses, the Windows OpenSSH agent closes the connection) — any other exception now fails the test instead of silently skipping.

## Test plan

- [x] Full solution builds; test suite passes (42 passed), including the Pageant skip paths against a real Pageant