### PR TITLE
Replace the net8.0 DefineConstants shim with real conditionals

### DIFF
--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if !NETFRAMEWORK
 using System;
 using System.Runtime.InteropServices;
 #endif
@@ -17,7 +17,7 @@ namespace SshNet.Agent
         /// <summary>Creates the client; Pageant itself must already be running.</summary>
         public Pageant()
         {
-#if NETSTANDARD
+#if !NETFRAMEWORK
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 throw new NotSupportedException("Pageant is Windows only");

--- a/SshNet.Agent/SshAgentSocketStream.cs
+++ b/SshNet.Agent/SshAgentSocketStream.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 #endif
@@ -17,7 +17,7 @@ namespace SshNet.Agent
         private readonly NamedPipeClientStream? _pipe;
         private readonly Stream _stream;
         private readonly TimeSpan _timeout;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
         private readonly Socket? _socket;
 #endif
 
@@ -108,7 +108,7 @@ namespace SshNet.Agent
         public SshAgentSocketStream(string socketPath, TimeSpan timeout)
         {
             _timeout = timeout;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
             if (UseUnixSocket(socketPath))
             {
                 _socket = CreateUnixSocket(timeout);
@@ -122,7 +122,7 @@ namespace SshNet.Agent
             _stream = _pipe;
         }
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
         private SshAgentSocketStream(Socket socket, TimeSpan timeout)
         {
             _socket = socket;
@@ -140,7 +140,7 @@ namespace SshNet.Agent
 
         public static async Task<SshAgentSocketStream> ConnectAsync(string socketPath, TimeSpan timeout, CancellationToken cancellationToken)
         {
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
             if (UseUnixSocket(socketPath))
             {
                 var socket = CreateUnixSocket(timeout);
@@ -175,7 +175,7 @@ namespace SshNet.Agent
             return new SshAgentSocketStream(pipe, timeout);
         }
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
         /// <summary>
         /// Everything on unix is a unix domain socket; on Windows only paths
         /// that exist as files are (e.g. WSL sockets), never pipe paths.
@@ -221,7 +221,7 @@ namespace SshNet.Agent
             if (!_disposed && disposing)
             {
                 _stream.Dispose();
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET
                 _socket?.Dispose();
 #endif
                 _pipe?.Dispose();

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -22,13 +22,6 @@
         <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     </PropertyGroup>
 
-    <!-- The sources gate the unix socket support and platform guards on the
-         NETSTANDARD(2_1) symbols; net8.0 has all of those APIs, so define them
-         there instead of widening every #if. -->
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_1</DefineConstants>
-    </PropertyGroup>
-
     <PropertyGroup Label="SourceLink and symbols">
         <RepositoryUrl>https://github.com/darinkes/SshNet.Agent</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Summary

The net8.0 TFM PR defined `NETSTANDARD;NETSTANDARD2_1` for net8.0 in the csproj to avoid conflicting with the then-open I/O PRs that were reworking the same `#if` lines. Those are all merged, so this replaces the shim with honest conditionals:

- unix domain socket support: `#if NETSTANDARD2_1 || NET` (NET is defined for .NET 5+)
- Pageant platform guard: `#if !NETFRAMEWORK` (net48 is always Windows)
- the csproj `DefineConstants` block is removed

## Test plan

- [x] Non-incremental build of all four TFMs, zero errors; full suite passes (42 passed)
- [x] Verified by reflection/binary inspection that the net8.0 assembly still contains `CreateUnixSocket` and the "Pageant is Windows only" guard — the silent failure mode of a wrong conditional would be net8.0 compiling without them