### PR TITLE
Complete the async API: constrained adds and lock/unlock

### DIFF
--- a/SshNet.Agent.Tests/AsyncApiTests.cs
+++ b/SshNet.Agent.Tests/AsyncApiTests.cs
@@ -105,6 +105,50 @@ namespace SshNet.Agent.Tests
         }
 
         [Fact]
+        public async Task AddIdentityAsync_WithConstraints_SendsTheConstrainedMessage()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            var keyFile = new PrivateKeyFile(TestKeys.PrivateKeyPath(TestKeys.Ed25519Puttygen));
+
+            await fake.CreateClient().AddIdentityAsync(keyFile, TimeSpan.FromMinutes(10), confirm: true,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(25, request.Byte()); // SSH2_AGENTC_ADD_ID_CONSTRAINED
+            request.Text(); // key type
+            request.Str(); // public key
+            request.Str(); // private key
+            request.Str(); // comment
+            Assert.Equal(1, request.Byte()); // SSH_AGENT_CONSTRAIN_LIFETIME
+            Assert.Equal(600u, request.U32());
+            Assert.Equal(2, request.Byte()); // SSH_AGENT_CONSTRAIN_CONFIRM
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public async Task LockAsyncAndUnlockAsync_SendThePassphrase()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+            var agent = fake.CreateClient();
+
+            await agent.LockAsync("correct horse battery staple", TestContext.Current.CancellationToken);
+            await agent.UnlockAsync("correct horse battery staple", TestContext.Current.CancellationToken);
+
+            Assert.True(fake.Requests.TryDequeue(out var rawLock));
+            var lockRequest = new WireReader(rawLock!);
+            Assert.Equal(22, lockRequest.Byte()); // SSH_AGENTC_LOCK
+            Assert.Equal("correct horse battery staple", lockRequest.Text());
+
+            Assert.True(fake.Requests.TryDequeue(out var rawUnlock));
+            var unlockRequest = new WireReader(rawUnlock!);
+            Assert.Equal(23, unlockRequest.Byte()); // SSH_AGENTC_UNLOCK
+            Assert.Equal("correct horse battery staple", unlockRequest.Text());
+        }
+
+        [Fact]
         public async Task CanceledToken_CancelsTheRequest()
         {
             using var fake = new FakeAgent();

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -174,6 +174,24 @@ namespace SshNet.Agent
             _ = await SendAsync(new RemoveIdentity(), cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>Async variant of <see cref="AddIdentity(IPrivateKeySource, TimeSpan?, bool)"/>.</summary>
+        public async Task AddIdentityAsync(IPrivateKeySource keyFile, TimeSpan? lifetime, bool confirm = false, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new AddIdentity(keyFile, lifetime, confirm), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="Lock"/>.</summary>
+        public async Task LockAsync(string passphrase, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new LockAgent(true, passphrase), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="Unlock"/>.</summary>
+        public async Task UnlockAsync(string passphrase, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new LockAgent(false, passphrase), cancellationToken).ConfigureAwait(false);
+        }
+
         internal virtual async Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)
         {
             // messages serialize into memory, so only the transport needs to be


### PR DESCRIPTION
## Summary

Closes the remaining async API gaps: `LockAsync`, `UnlockAsync` and the constrained `AddIdentityAsync(keyFile, lifetime, confirm)` overload, all taking an optional `CancellationToken` and going through the same async transport as the rest.

## Test plan

- [x] Golden-byte tests: constrained async add sends `SSH2_AGENTC_ADD_ID_CONSTRAINED` with the lifetime and confirm trailers; lock/unlock send the passphrase with the right message types
- [x] Full suite passes (44 passed); CS1591-as-error keeps the new members documented