### PR TITLE
Test the lowest supported SSH.NET in CI

### DIFF
--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -29,6 +29,10 @@ jobs:
       run: dotnet test --no-build --verbosity normal
       env:
         SSHNET_AGENT_TESTS_REQUIRED: OpenSsh,Pageant,Server
+    - name: Test against the lowest supported SSH.NET
+      run: dotnet test --verbosity normal -p:SshNetVersion=2024.2.0
+      env:
+        SSHNET_AGENT_TESTS_REQUIRED: OpenSsh,Pageant,Server
     - uses: actions/upload-artifact@v5
       with:
         name: Sample-ubuntu

--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -39,6 +39,10 @@ jobs:
       run: dotnet test --no-build --verbosity normal
       env:
         SSHNET_AGENT_TESTS_REQUIRED: OpenSsh,Pageant,Server
+    - name: Test against the lowest supported SSH.NET
+      run: dotnet test --verbosity normal -p:SshNetVersion=2024.2.0
+      env:
+        SSHNET_AGENT_TESTS_REQUIRED: OpenSsh,Pageant,Server
     - uses: actions/upload-artifact@v5
       with:
         name: sample-windows

--- a/SshNet.Agent.Tests/SshNet.Agent.Tests.csproj
+++ b/SshNet.Agent.Tests/SshNet.Agent.Tests.csproj
@@ -18,6 +18,19 @@
         <ProjectReference Include="..\SshNet.Agent\SshNet.Agent.csproj" />
     </ItemGroup>
 
+    <!-- CI runs a second test leg with -p:SshNetVersion=2024.2.0 so the lowest
+         SSH.NET the library claims to support stays tested; without the pin,
+         Testcontainers pulls the newest SSH.NET into the test graph. Its own
+         SSH.NET-based features (SSH port forwarding) are not used by these
+         tests, hence the NU1608 suppression for the pinned leg. -->
+    <ItemGroup Condition="'$(SshNetVersion)' != ''">
+        <PackageReference Include="SSH.NET" Version="[$(SshNetVersion)]" />
+    </ItemGroup>
+    <PropertyGroup Condition="'$(SshNetVersion)' != ''">
+        <!-- NU1605: the pin is a deliberate downgrade below Testcontainers' minimum -->
+        <NoWarn>$(NoWarn);NU1608;NU1605</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="TestKeys\**" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

Since Testcontainers 4.13 depends on SSH.NET 2025.1.0, the test graph always resolves the newest SSH.NET — meaning the floor of the library's declared range (`2024.2.0`) was not tested by any build. A change accidentally requiring a 2025.x API would pass CI green while breaking consumers on the documented minimum.

Both workflows now run a second test leg with `-p:SshNetVersion=2024.2.0`, which pins the test graph to the floor via a conditional direct reference. The pin is a deliberate downgrade below Testcontainers' minimum, so NU1605/NU1608 are suppressed **only for that leg**; Testcontainers' SSH.NET-based features (SSH port forwarding to remote Docker hosts) are not exercised by these tests.

## Test plan

- [x] Local floor leg: resolves `SSH.NET/2024.2.0`, 42 tests pass
- [x] Local default leg unchanged: resolves `SSH.NET/2025.1.0`, 42 tests pass