### PR TITLE
Trust the test CA on the Windows CI sshd

### DIFF
--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -34,7 +34,18 @@ jobs:
         Get-Content SshNet.Agent.Tests\TestKeys\ed25519_puttygen.pub, SshNet.Agent.Tests\TestKeys\ed25519_zerolead.pub, SshNet.Agent.Tests\TestKeys\rsa_a.pub, SshNet.Agent.Tests\TestKeys\ecdsa_256.pub | Set-Content $authorizedKeys
         icacls $authorizedKeys /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'
         Start-Service sshd
+        # trust the test CA for certificate authentication; the certificates
+        # carry the principal "test", which the static principals file maps to
+        # every user (the runner user is not "test")
+        Copy-Item SshNet.Agent.Tests\TestKeys\test_ca.pub C:\ProgramData\ssh\test_ca.pub
+        Set-Content C:\ProgramData\ssh\principals 'test'
+        icacls C:\ProgramData\ssh\test_ca.pub /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'
+        icacls C:\ProgramData\ssh\principals /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'
+        Add-Content C:\ProgramData\ssh\sshd_config 'TrustedUserCAKeys __PROGRAMDATA__/ssh/test_ca.pub'
+        Add-Content C:\ProgramData\ssh\sshd_config 'AuthorizedPrincipalsFile __PROGRAMDATA__/ssh/principals'
+        Restart-Service sshd
         "SSHNET_AGENT_SERVER=127.0.0.1:22:$env:UserName" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "SSHNET_AGENT_SERVER_TRUSTS_CA=1" | Out-File -FilePath $env:GITHUB_ENV -Append
     - name: Test
       run: dotnet test --no-build --verbosity normal
       env:

--- a/SshNet.Agent.Tests/RealWorldTests.cs
+++ b/SshNet.Agent.Tests/RealWorldTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using Renci.SshNet;
 using Xunit;
@@ -151,9 +152,23 @@ namespace SshNet.Agent.Tests
         {
             _server.SkipUnlessAvailable();
             _server.SkipUnlessTrustsTestCa();
-            using var agent = TestAgent.Start(kind, TestKeys.Ed25519Cert);
+            using var agent = StartWithCertificate(kind);
 
             Assert.Equal("ok", Login(agent.Identity(TestKeys.Ed25519Cert)));
+        }
+
+        private static TestAgent StartWithCertificate(AgentKind kind)
+        {
+            try
+            {
+                return TestAgent.Start(kind, TestKeys.Ed25519Cert);
+            }
+            catch (Exception e) when (e is SshAgentFailureException or EndOfStreamException)
+            {
+                // certificate support varies by agent, like constraints and locking
+                Assert.Skip($"the agent does not support certificate identities ({e.Message})");
+                throw; // unreachable, Assert.Skip does not return
+            }
         }
 
         /// <summary>

--- a/SshNet.Agent.Tests/SshServerFixture.cs
+++ b/SshNet.Agent.Tests/SshServerFixture.cs
@@ -40,6 +40,7 @@ namespace SshNet.Agent.Tests
                 Host = parts[0];
                 Port = int.Parse(parts[1]);
                 User = parts[2];
+                TrustsTestCa = Environment.GetEnvironmentVariable("SSHNET_AGENT_SERVER_TRUSTS_CA") == "1";
                 return;
             }
 


### PR DESCRIPTION
## Summary

The certificate real-world test skipped on the Windows job because the native sshd there did not trust the test CA — coverage existed only on Ubuntu (Docker). Now:

- The Windows workflow configures `TrustedUserCAKeys` for the checked-in test CA **after** the first sshd start has generated the default config, and restarts sshd. The test certificates carry the principal `test` while the runner user does not match it, so a static `AuthorizedPrincipalsFile` maps that principal to every user.
- The fixture flags CA trust for external servers via the new `SSHNET_AGENT_SERVER_TRUSTS_CA` environment variable.
- Whether the **Windows OpenSSH agent** accepts certificate identities is unproven (it refuses locking by closing the connection), so the test now uses the same skip-on-refusal pattern as constraints/locking instead of failing — the first CI run of this PR answers that question either way.

## Test plan

- [x] Full solution builds; suite passes locally (cert test passes via Pageant + Docker sshd, unaffected by the workflow change)
- [ ] Windows CI run of this PR: certificate test either passes against the native sshd or skips with the agent's refusal reason — not silently