### PR TITLE
Modernize the sample

### DIFF
--- a/SshNet.Agent.Sample/Program.cs
+++ b/SshNet.Agent.Sample/Program.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Renci.SshNet;
 
+// The public keys of the embedded sample keys, ready to paste into
+// ~/.ssh/authorized_keys on the demo server for the host/user login:
+//
 // ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE5W6BcNnMuNgLYuUa18F/Ci8dzPqeIO/H333n0yv4o6
 // ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEqKSQ9hDmbqz04emjXekb3wRuP1SIhGC+kRd8VjbjSfZA/av6nTU7d2wkxO0IFIjeC7x95tvtVvxXQqNa8VRXE=
 // ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBEccBcSqsk28fdeLH8FBKG2AbcLslKl8DoJACAK3QoVMz1Mj/0gY/FOkqMbYgR6fAlxM06YJI8GmFO6jbcqX9P0MvyUfAXN1Tt4ljbn0/7fAP08HP+gzGSHZsTj1l0MGjA==
@@ -16,64 +20,119 @@ using Renci.SshNet;
 
 namespace SshNet.Agent.Sample
 {
-    class Program
+    /// <summary>
+    /// Demonstrates SshNet.Agent against a running key agent:
+    ///
+    ///   SshNet.Agent.Sample [--pageant] [host user]
+    ///
+    /// --pageant talks to PuTTY's Pageant instead of the OpenSSH agent. When a
+    /// host and user are given, the sample additionally authenticates against
+    /// that SSH server with the identities the agent serves. The sample only
+    /// removes the keys it added itself; identities already in the agent are
+    /// left alone.
+    /// </summary>
+    internal static class Program
     {
-        static void Main(string[] args)
+        private static readonly string[] SampleKeys =
         {
+            "ed25519", "ecdsa256", "ecdsa384", "ecdsa521", "rsa2048", "rsa3072", "rsa4096", "rsa8192"
+        };
+
+        private static async Task Main(string[] args)
+        {
+            SshAgent agent = args.Contains("--pageant") ? new Pageant() : new SshAgent();
+
+            var before = ListedBlobs(await agent.RequestIdentitiesAsync());
+            Console.WriteLine($"The agent holds {before.Count} identities.");
+
             try
             {
-#if NETFRAMEWORK
-                var agent = new Pageant();
-#else
-                var agent = new SshAgent();
-#endif
+                Console.WriteLine("Adding the sample keys ...");
+                foreach (var name in SampleKeys)
+                    await agent.AddIdentityAsync(new PrivateKeyFile(GetKey(name)));
 
-                agent.RemoveAllIdentities();
+                foreach (var identity in await agent.RequestIdentitiesAsync())
+                    Console.WriteLine($"  {string.Join(", ", identity.HostKeyAlgorithms.Select(algorithm => algorithm.Name))}");
 
-                var testKeys = new[]
+                await LifetimeDemo(agent);
+                await LockDemo(agent);
+
+                var positional = args.Where(arg => !arg.StartsWith("--")).ToArray();
+                if (positional.Length == 2)
+                    Login(agent, positional[0], positional[1]);
+            }
+            finally
+            {
+                foreach (var identity in await agent.RequestIdentitiesAsync())
                 {
-                    "ed25519", "ecdsa256", "ecdsa384", "ecdsa521", "rsa2048", "rsa3072", "rsa4096", "rsa8192"
-                };
-
-                foreach (var testKey in testKeys)
-                {
-                    Console.WriteLine($"Testing Key {testKey}");
-                    var keyFile = new PrivateKeyFile(GetKey(testKey));
-                    agent.AddIdentity(keyFile);
-
-                    var keys = agent.RequestIdentities();
-
-                    try
-                    {
-                        using var client = new SshClient("localhost", Environment.GetEnvironmentVariable("USER") ?? Environment.GetEnvironmentVariable("USERNAME"), keys.ToArray<IPrivateKeySource>());
-                        client.Connect();
-                        Console.WriteLine(client.RunCommand("hostname").Result.Trim());
-                        Console.WriteLine($"Key {testKey} worked!");
-                        Console.WriteLine();
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine(e);
-                        Console.ReadLine();
-                    }
-                    agent.RemoveIdentities(keys.ToList());
-
-                    if (agent.RequestIdentities().Any())
-                        throw new Exception("There should be no keys!");
+                    if (!before.Contains(Blob(identity)))
+                        await agent.RemoveIdentityAsync(identity);
                 }
+                Console.WriteLine("Sample keys removed again.");
+            }
+        }
+
+        /// <summary>A key with a lifetime (ssh-add -t) expires from the agent by itself.</summary>
+        private static async Task LifetimeDemo(SshAgent agent)
+        {
+            Console.WriteLine("Re-adding the ed25519 key with a 2s lifetime (ssh-add -t) ...");
+            try
+            {
+                agent.AddIdentity(new PrivateKeyFile(GetKey("ed25519")), TimeSpan.FromSeconds(2));
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
-                throw;
+                Console.WriteLine($"  this agent does not support constraints ({e.Message})");
+                return;
             }
-            Console.WriteLine("Done");
-            Console.ReadLine();
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            var count = (await agent.RequestIdentitiesAsync()).Length;
+            Console.WriteLine($"  after 3s the agent lists {count} identities, the key expired");
         }
 
-        private static Stream GetKey(string keyname)
+        /// <summary>A locked agent (ssh-add -x) hides its identities until unlocked.</summary>
+        private static async Task LockDemo(SshAgent agent)
         {
-            return Assembly.GetExecutingAssembly().GetManifestResourceStream($"SshNet.Agent.Sample.TestKeys.{keyname}");
+            Console.WriteLine("Locking the agent (ssh-add -x) ...");
+            try
+            {
+                agent.Lock("passphrase");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"  this agent does not support locking ({e.Message})");
+                return;
+            }
+
+            Console.WriteLine($"  locked: the agent lists {(await agent.RequestIdentitiesAsync()).Length} identities");
+            agent.Unlock("passphrase");
+            Console.WriteLine($"  unlocked: the agent lists {(await agent.RequestIdentitiesAsync()).Length} identities again");
+        }
+
+        private static void Login(SshAgent agent, string host, string user)
+        {
+            Console.WriteLine($"Authenticating as {user}@{host} with the agent identities ...");
+            var keys = agent.RequestIdentities();
+            using var client = new SshClient(new ConnectionInfo(host, user,
+                new PrivateKeyAuthenticationMethod(user, keys)));
+            client.Connect();
+            Console.WriteLine($"  {client.RunCommand("hostname").Result.Trim()}");
+        }
+
+        private static HashSet<string> ListedBlobs(IEnumerable<SshAgentPrivateKey> identities)
+        {
+            return new HashSet<string>(identities.Select(Blob));
+        }
+
+        private static string Blob(SshAgentPrivateKey identity)
+        {
+            return Convert.ToBase64String(identity.HostKeyAlgorithms.First().Data);
+        }
+
+        private static Stream GetKey(string name)
+        {
+            return Assembly.GetExecutingAssembly().GetManifestResourceStream($"SshNet.Agent.Sample.TestKeys.{name}");
         }
     }
 }

--- a/SshNet.Agent.Sample/Program.cs
+++ b/SshNet.Agent.Sample/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -21,15 +22,9 @@ using Renci.SshNet;
 namespace SshNet.Agent.Sample
 {
     /// <summary>
-    /// Demonstrates SshNet.Agent against a running key agent:
-    ///
-    ///   SshNet.Agent.Sample [--pageant] [host user]
-    ///
-    /// --pageant talks to PuTTY's Pageant instead of the OpenSSH agent. When a
-    /// host and user are given, the sample additionally authenticates against
-    /// that SSH server with the identities the agent serves. The sample only
+    /// Demonstrates SshNet.Agent against a running key agent. The sample only
     /// removes the keys it added itself; identities already in the agent are
-    /// left alone.
+    /// left alone. See --help for the options.
     /// </summary>
     internal static class Program
     {
@@ -38,10 +33,44 @@ namespace SshNet.Agent.Sample
             "ed25519", "ecdsa256", "ecdsa384", "ecdsa521", "rsa2048", "rsa3072", "rsa4096", "rsa8192"
         };
 
-        private static async Task Main(string[] args)
+        private static Task<int> Main(string[] args)
         {
-            SshAgent agent = args.Contains("--pageant") ? new Pageant() : new SshAgent();
+            var pageantOption = new Option<bool>("--pageant")
+            {
+                Description = "Talk to PuTTY's Pageant instead of the OpenSSH agent"
+            };
+            var hostArgument = new Argument<string?>("host")
+            {
+                Description = "SSH server to authenticate against with the agent identities",
+                Arity = ArgumentArity.ZeroOrOne
+            };
+            var userArgument = new Argument<string?>("user")
+            {
+                Description = "User to authenticate as",
+                Arity = ArgumentArity.ZeroOrOne
+            };
 
+            var command = new RootCommand("Demonstrates SshNet.Agent against a running key agent")
+            {
+                pageantOption,
+                hostArgument,
+                userArgument
+            };
+            command.Validators.Add(result =>
+            {
+                if (result.GetValue(hostArgument) is not null && result.GetValue(userArgument) is null)
+                    result.AddError("A host also needs a user.");
+            });
+            command.SetAction((result, _) => RunDemo(
+                result.GetValue(pageantOption) ? new Pageant() : new SshAgent(),
+                result.GetValue(hostArgument),
+                result.GetValue(userArgument)));
+
+            return command.Parse(args).InvokeAsync();
+        }
+
+        private static async Task<int> RunDemo(SshAgent agent, string? host, string? user)
+        {
             var before = ListedBlobs(await agent.RequestIdentitiesAsync());
             Console.WriteLine($"The agent holds {before.Count} identities.");
 
@@ -57,9 +86,8 @@ namespace SshNet.Agent.Sample
                 await LifetimeDemo(agent);
                 await LockDemo(agent);
 
-                var positional = args.Where(arg => !arg.StartsWith("--")).ToArray();
-                if (positional.Length == 2)
-                    Login(agent, positional[0], positional[1]);
+                if (host is not null && user is not null)
+                    Login(agent, host, user);
             }
             finally
             {
@@ -70,6 +98,8 @@ namespace SshNet.Agent.Sample
                 }
                 Console.WriteLine("Sample keys removed again.");
             }
+
+            return 0;
         }
 
         /// <summary>A key with a lifetime (ssh-add -t) expires from the agent by itself.</summary>
@@ -132,7 +162,7 @@ namespace SshNet.Agent.Sample
 
         private static Stream GetKey(string name)
         {
-            return Assembly.GetExecutingAssembly().GetManifestResourceStream($"SshNet.Agent.Sample.TestKeys.{name}");
+            return Assembly.GetExecutingAssembly().GetManifestResourceStream($"SshNet.Agent.Sample.TestKeys.{name}")!;
         }
     }
 }

--- a/SshNet.Agent.Sample/SshNet.Agent.Sample.csproj
+++ b/SshNet.Agent.Sample/SshNet.Agent.Sample.csproj
@@ -5,6 +5,7 @@
         <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;net8.0</TargetFrameworks>
         <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <Nullable>enable</Nullable>
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 
@@ -14,6 +15,10 @@
 
     <ItemGroup>
         <EmbeddedResource Include="TestKeys\*" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.CommandLine" Version="2.0.9" />
     </ItemGroup>
 
 </Project>

--- a/SshNet.Agent.Sample/SshNet.Agent.Sample.csproj
+++ b/SshNet.Agent.Sample/SshNet.Agent.Sample.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;net8.0</TargetFrameworks>
         <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFramework>
+        <RollForward>LatestMajor</RollForward>
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Two commits:

**Modernize the sample** — the sample still showed only the original add/list/remove loop and wiped the whole agent with `RemoveAllIdentities`. Now it:

- lists identities with **all** offered algorithms (`rsa-sha2-512, rsa-sha2-256`),
- uses the async API for add/list/remove,
- demonstrates lifetime constraints and locking, reporting gracefully when the agent refuses them (Pageant does),
- authenticates against a server only when `host user` arguments are given (instead of hardcoded localhost),
- removes **only the keys it added itself** — a real agent's identities are left alone,
- gets `RollForward` so the net8.0 build runs on newer installed runtimes,
- keeps the public keys of the sample keys as a comment block, ready to paste into `~/.ssh/authorized_keys` on the demo server.

**Parse the sample arguments with System.CommandLine** — replaces the hand-rolled argument handling with System.CommandLine 2.0 (stable, netstandard2.0, so the net48 build keeps working): `--pageant` as a documented option, `host`/`user` as optional positional arguments with validation ("A host also needs a user."), plus `--help`/`--version` for free.

## Test plan

- [x] Builds for net48 and net8.0
- [x] Ran end-to-end against a real Pageant: 8 keys added and listed, constraint/lock demos report Pageant's refusal, exactly the added keys removed again; `--help` output and argument validation verified
