### PR TITLE
Log the agent conversation through ILogger

### DIFF
--- a/SshNet.Agent.Sample/Program.cs
+++ b/SshNet.Agent.Sample/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -39,6 +40,10 @@ namespace SshNet.Agent.Sample
             {
                 Description = "Talk to PuTTY's Pageant instead of the OpenSSH agent"
             };
+            var verboseOption = new Option<bool>("--verbose", "-v")
+            {
+                Description = "Print the raw messages exchanged with the agent"
+            };
             var hostArgument = new Argument<string?>("host")
             {
                 Description = "SSH server to authenticate against with the agent identities",
@@ -53,6 +58,7 @@ namespace SshNet.Agent.Sample
             var command = new RootCommand("Demonstrates SshNet.Agent against a running key agent")
             {
                 pageantOption,
+                verboseOption,
                 hostArgument,
                 userArgument
             };
@@ -61,12 +67,46 @@ namespace SshNet.Agent.Sample
                 if (result.GetValue(hostArgument) is not null && result.GetValue(userArgument) is null)
                     result.AddError("A host also needs a user.");
             });
-            command.SetAction((result, _) => RunDemo(
-                result.GetValue(pageantOption) ? new Pageant() : new SshAgent(),
-                result.GetValue(hostArgument),
-                result.GetValue(userArgument)));
+            command.SetAction((result, _) =>
+            {
+                SshAgent agent = result.GetValue(pageantOption) ? new Pageant() : new SshAgent();
+                if (result.GetValue(verboseOption))
+                    agent.Logger = new HexDumpLogger();
+                return RunDemo(agent, result.GetValue(hostArgument), result.GetValue(userArgument));
+            });
 
             return command.Parse(args).InvokeAsync();
+        }
+
+        /// <summary>
+        /// The library logs each raw agent message as SshAgentTraceMessage
+        /// state and leaves the representation to the attached logger; this
+        /// one hex-dumps the traffic, like a tiny Wireshark.
+        /// </summary>
+        private sealed class HexDumpLogger : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (state is not SshAgentTraceMessage message)
+                {
+                    Console.WriteLine(formatter(state, exception));
+                    return;
+                }
+
+                Console.WriteLine($"{(message.Direction == SshAgentTraceDirection.Request ? "->" : "<-")} {message.Data.Length} bytes");
+                for (var offset = 0; offset < message.Data.Length; offset += 16)
+                {
+                    var chunk = message.Data.Skip(offset).Take(16).ToArray();
+                    var hex = string.Join(" ", chunk.Select(value => value.ToString("x2"))).PadRight(47);
+                    var ascii = new string(chunk.Select(value => value is >= 0x20 and < 0x7f ? (char)value : '.').ToArray());
+                    Console.WriteLine($"   {offset:x4}  {hex}  {ascii}");
+                }
+            }
         }
 
         private static async Task<int> RunDemo(SshAgent agent, string? host, string? user)

--- a/SshNet.Agent.Tests/AgentLoggingTests.cs
+++ b/SshNet.Agent.Tests/AgentLoggingTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    /// <summary>
+    /// An attached ILogger sees every raw agent message at Trace level as
+    /// structured SshAgentTraceMessage state, one entry per request and one
+    /// per response, each including the length prefix.
+    /// </summary>
+    public class AgentLoggingTests
+    {
+        private const byte Ssh2AgentIdentitiesAnswer = 12;
+
+        private static byte[] Framed(byte[] payload)
+        {
+            return Wire.Cat(Wire.U32((uint)payload.Length), payload);
+        }
+
+        private sealed class CollectingLogger : ILogger
+        {
+            public bool Enabled { get; set; } = true;
+
+            public List<(LogLevel Level, EventId EventId, SshAgentTraceMessage Message, string Text)> Entries { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => Enabled;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var message = Assert.IsType<SshAgentTraceMessage>(state);
+                Entries.Add((logLevel, eventId, message, formatter(state, exception)));
+            }
+        }
+
+        [Fact]
+        public void Send_LogsTheRequestAndTheResponse()
+        {
+            using var fake = new FakeAgent();
+            var answer = Wire.Cat(new[] { Ssh2AgentIdentitiesAnswer }, Wire.U32(0));
+            fake.EnqueueResponse(answer);
+            var logger = new CollectingLogger();
+            var agent = fake.CreateClient();
+            agent.Logger = logger;
+
+            agent.RequestIdentities();
+
+            Assert.Equal(2, logger.Entries.Count);
+            var request = logger.Entries[0];
+            Assert.Equal(LogLevel.Trace, request.Level);
+            Assert.Equal("AgentMessage", request.EventId.Name);
+            Assert.Equal(SshAgentTraceDirection.Request, request.Message.Direction);
+            Assert.Equal(Framed(fake.SingleRequest()), request.Message.Data);
+            Assert.Equal("Request agent message, 5 bytes", request.Text);
+
+            var response = logger.Entries[1];
+            Assert.Equal(SshAgentTraceDirection.Response, response.Message.Direction);
+            Assert.Equal(Framed(answer), response.Message.Data);
+        }
+
+        [Fact]
+        public async Task SendAsync_LogsTheRequestAndTheResponse()
+        {
+            using var fake = new FakeAgent();
+            var answer = Wire.Cat(new[] { Ssh2AgentIdentitiesAnswer }, Wire.U32(0));
+            fake.EnqueueResponse(answer);
+            var logger = new CollectingLogger();
+            var agent = fake.CreateClient();
+            agent.Logger = logger;
+
+            await agent.RequestIdentitiesAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(2, logger.Entries.Count);
+            Assert.Equal(SshAgentTraceDirection.Request, logger.Entries[0].Message.Direction);
+            Assert.Equal(Framed(fake.SingleRequest()), logger.Entries[0].Message.Data);
+            Assert.Equal(SshAgentTraceDirection.Response, logger.Entries[1].Message.Direction);
+            Assert.Equal(Framed(answer), logger.Entries[1].Message.Data);
+        }
+
+        [Fact]
+        public void DisabledLogger_SeesNothing()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(Wire.Cat(new[] { Ssh2AgentIdentitiesAnswer }, Wire.U32(0)));
+            var logger = new CollectingLogger { Enabled = false };
+            var agent = fake.CreateClient();
+            agent.Logger = logger;
+
+            agent.RequestIdentities();
+
+            Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
+        public void TraceMessage_ExposesStructuredProperties()
+        {
+            var data = new byte[] { 0, 0, 0, 1, 11 };
+            var message = new SshAgentTraceMessage(SshAgentTraceDirection.Request, data);
+
+            var properties = new Dictionary<string, object?>();
+            foreach (var pair in message)
+                properties[pair.Key] = pair.Value;
+
+            Assert.Equal(SshAgentTraceDirection.Request, properties["Direction"]);
+            Assert.Equal(5, properties["DataLength"]);
+            Assert.Equal(data, properties["Data"]);
+            Assert.Equal("{Direction} agent message, {DataLength} bytes", properties["{OriginalFormat}"]);
+        }
+    }
+}

--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -27,13 +27,16 @@ namespace SshNet.Agent
 
         internal override object? Send(IAgentMessage message)
         {
-            using var socketStream = new PageantSocketStream();
-            using var writer = new AgentWriter(socketStream);
-            using var reader = new AgentReader(socketStream);
+            var request = Serialize(message);
+            LogMessage(SshAgentTraceDirection.Request, request);
 
-            message.To(writer);
+            using var socketStream = new PageantSocketStream();
+            socketStream.Write(request, 0, request.Length);
             socketStream.Send();
-            return message.From(reader);
+            var response = ReadMessage(socketStream);
+            LogMessage(SshAgentTraceDirection.Response, response);
+
+            return Parse(message, response);
         }
 
         internal override Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Renci.SshNet;
 using Renci.SshNet.Security;
 using SshNet.Agent.AgentMessage;
@@ -27,6 +29,25 @@ namespace SshNet.Agent
         /// support (OpenSSH older than 7.2).
         /// </summary>
         public bool IncludeLegacySshRsa { get; set; }
+
+        /// <summary>
+        /// Logger for the agent conversation. At Trace level every raw
+        /// protocol message is logged as a <see cref="SshAgentTraceMessage"/>
+        /// with its direction and complete framed payload; the default text
+        /// rendering only summarizes it, the representation of the raw data is
+        /// up to the attached logger. Beware that requests contain private key
+        /// material when identities are added.
+        /// </summary>
+        public ILogger Logger { get; set; } = NullLogger.Instance;
+
+        private static readonly EventId AgentMessageEvent = new EventId(1, "AgentMessage");
+
+        internal void LogMessage(SshAgentTraceDirection direction, byte[] data)
+        {
+            if (Logger.IsEnabled(LogLevel.Trace))
+                Logger.Log(LogLevel.Trace, AgentMessageEvent, new SshAgentTraceMessage(direction, data), null,
+                    (state, _) => $"{state.Direction} agent message, {state.Data.Length} bytes");
+        }
 
         /// <summary>
         /// Uses the agent from the SSH_AUTH_SOCK environment variable, or the
@@ -129,12 +150,15 @@ namespace SshNet.Agent
 
         internal virtual object? Send(IAgentMessage message)
         {
-            using var socketStream = new SshAgentSocketStream(_socketPath, _timeout);
-            using var writer = new AgentWriter(socketStream);
-            using var reader = new AgentReader(socketStream);
+            var request = Serialize(message);
+            LogMessage(SshAgentTraceDirection.Request, request);
 
-            message.To(writer);
-            return message.From(reader);
+            using var socketStream = new SshAgentSocketStream(_socketPath, _timeout);
+            socketStream.Write(request, 0, request.Length);
+            var response = ReadMessage(socketStream);
+            LogMessage(SshAgentTraceDirection.Response, response);
+
+            return Parse(message, response);
         }
 
         /// <summary>Async variant of <see cref="RequestIdentities"/>.</summary>
@@ -176,28 +200,66 @@ namespace SshNet.Agent
 
         internal virtual async Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)
         {
-            // messages serialize into memory, so only the transport needs to be
-            // asynchronous; the response is read completely before parsing
-            byte[] request;
-            using (var requestStream = new MemoryStream())
-            {
-                using (var writer = new AgentWriter(requestStream))
-                {
-                    message.To(writer);
-                }
-                request = requestStream.ToArray();
-            }
+            var request = Serialize(message);
+            LogMessage(SshAgentTraceDirection.Request, request);
 
             using var socketStream = await SshAgentSocketStream.ConnectAsync(_socketPath, _timeout, cancellationToken).ConfigureAwait(false);
             await socketStream.WriteAsync(request, 0, request.Length, cancellationToken).ConfigureAwait(false);
             var response = await ReadMessageAsync(socketStream, cancellationToken).ConfigureAwait(false);
+            LogMessage(SshAgentTraceDirection.Response, response);
 
+            return Parse(message, response);
+        }
+
+        /// <summary>
+        /// Messages serialize into memory, so only the transport needs to
+        /// care about timeouts and the response is read completely before
+        /// parsing; the returned buffer is the complete framed message.
+        /// </summary>
+        internal static byte[] Serialize(IAgentMessage message)
+        {
+            using var requestStream = new MemoryStream();
+            using (var writer = new AgentWriter(requestStream))
+            {
+                message.To(writer);
+            }
+            return requestStream.ToArray();
+        }
+
+        internal static object? Parse(IAgentMessage message, byte[] response)
+        {
             using var responseStream = new MemoryStream(response);
             using var reader = new AgentReader(responseStream);
             return message.From(reader);
         }
 
         private const int MaxMessageLength = 256 * 1024; // OpenSSH AGENT_MAX_MSGLEN
+
+        /// <summary>Sync twin of <see cref="ReadMessageAsync"/>.</summary>
+        internal static byte[] ReadMessage(Stream stream)
+        {
+            var header = new byte[4];
+            ReadExactly(stream, header, 0);
+            var length = (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3];
+            if (length < 1 || length > MaxMessageLength)
+                throw new InvalidDataException($"Invalid agent message length {length}");
+
+            var message = new byte[4 + length];
+            Buffer.BlockCopy(header, 0, message, 0, 4);
+            ReadExactly(stream, message, 4);
+            return message;
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int offset)
+        {
+            while (offset < buffer.Length)
+            {
+                var read = stream.Read(buffer, offset, buffer.Length - offset);
+                if (read == 0)
+                    throw new EndOfStreamException("The agent closed the connection mid-message");
+                offset += read;
+            }
+        }
 
         /// <summary>
         /// Reads one agent message (uint32 length + payload) and returns it

--- a/SshNet.Agent/SshAgentTraceDirection.cs
+++ b/SshNet.Agent/SshAgentTraceDirection.cs
@@ -1,0 +1,12 @@
+namespace SshNet.Agent
+{
+    /// <summary>The direction of a traced agent protocol message.</summary>
+    public enum SshAgentTraceDirection
+    {
+        /// <summary>A request sent to the agent.</summary>
+        Request,
+
+        /// <summary>A response received from the agent.</summary>
+        Response,
+    }
+}

--- a/SshNet.Agent/SshAgentTraceMessage.cs
+++ b/SshNet.Agent/SshAgentTraceMessage.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SshNet.Agent
+{
+    /// <summary>
+    /// One raw agent protocol message as structured log state: text sinks
+    /// render the default summary line, structured sinks and custom loggers
+    /// get <see cref="Direction"/> and the raw <see cref="Data"/> and choose
+    /// their own representation.
+    /// </summary>
+    public readonly struct SshAgentTraceMessage : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        /// <summary>Whether the message went to or came from the agent.</summary>
+        public SshAgentTraceDirection Direction { get; }
+
+        /// <summary>The complete framed message, including the uint32 length prefix.</summary>
+        public byte[] Data { get; }
+
+        /// <summary>Captures one traced message.</summary>
+        public SshAgentTraceMessage(SshAgentTraceDirection direction, byte[] data)
+        {
+            Direction = direction;
+            Data = data;
+        }
+
+        /// <summary>The number of structured logging properties.</summary>
+        public int Count => 4;
+
+        /// <summary>The structured logging properties by index.</summary>
+        public KeyValuePair<string, object?> this[int index] => index switch
+        {
+            0 => new KeyValuePair<string, object?>("Direction", Direction),
+            1 => new KeyValuePair<string, object?>("DataLength", Data.Length),
+            2 => new KeyValuePair<string, object?>("Data", Data),
+            _ => new KeyValuePair<string, object?>("{OriginalFormat}", "{Direction} agent message, {DataLength} bytes"),
+        };
+
+        /// <summary>Enumerates the structured logging properties.</summary>
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (var index = 0; index < Count; index++)
+                yield return this[index];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -44,6 +44,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
         <PackageReference Include="SSH.NET" Version="[2024.2.0,2026.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

Wire-level logging for the agent conversation, done the `ILogger` way: the library logs the data, the **attached logger owns the representation**.

- **`SshAgent.Logger`** (`Microsoft.Extensions.Logging.Abstractions`, default `NullLogger.Instance`): at `Trace` level, every raw protocol message is logged with `EventId(1, "AgentMessage")`.
- **`SshAgentTraceMessage`** is the structured log state: it carries `Direction` and the complete framed `Data`, and implements `IReadOnlyList<KeyValuePair<string, object?>>` with `Direction`/`DataLength`/`Data`/`{OriginalFormat}` properties. Consequences:
  - plain text sinks render only the safe default — `Request agent message, 128 bytes` — no accidental byte dumps in logs,
  - structured sinks (Serilog, OTel, …) see the raw `byte[]` as a property and apply their own destructuring/redaction,
  - a custom `ILogger` pattern-matches the state and renders however it wants — the sample's `--verbose` does exactly that with a ~25-line `HexDumpLogger`.
- The XML docs warn that add-identity requests contain private key material; `Trace` is off in every default logging configuration.
- Dependency note: `Microsoft.Extensions.Logging.Abstractions` 8.0.3 is the exact version SSH.NET 2025.1.0 already depends on, so consumers on newer SSH.NET pay nothing extra; it is netstandard2.0 and works on all four target frameworks.
- Plumbing: both send paths now share buffered `Serialize`/`ReadMessage`/`Parse` helpers — as a side effect the **sync** path gains the message-length validation the async path already had.

Sample output of `SshNet.Agent.Sample --pageant --verbose`:

```
-> 5 bytes
   0000  00 00 00 01 0b                                   .....
<- 9 bytes
   0000  00 00 00 05 0c 00 00 00 00                       .........
Adding the sample keys ...
-> 128 bytes
   0000  00 00 00 7c 11 00 00 00 0b 73 73 68 2d 65 64 32  ...|.....ssh-ed2
   0010  35 35 31 39 00 00 00 20 4e 56 e8 17 0d 9c cb 8d  5519... NV......
```

**Stacked on #37** (the sample's `--verbose` builds on the System.CommandLine parser): merge #37 first; GitHub retargets this PR to `main` automatically when the branch is deleted.

## Test plan

- [x] New tests: sync and async sends log exactly two entries with the exact framed bytes, correct level/event id and the summary text; a disabled logger sees nothing (and costs nothing); the structured properties enumerate as documented
- [x] Full suite passes (46 tests); builds on all four target frameworks with CS1591-as-error
- [x] Ran live against a real Pageant with `--verbose` — hex dump above, including through the Pageant WM_COPYDATA transport
