### PR TITLE
Add Dependabot config for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # one PR for all compatible minor/patch bumps, majors stay separate
+      nuget-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Weekly Dependabot updates for NuGet packages and GitHub Actions. Minor/patch NuGet bumps are grouped into a single PR; majors stay separate. Actions updates are grouped into one PR.