### PR TITLE
Add FIDO/security key signing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Note: Only the netstandard 2.1 and .NET 8.0 builds contain support for Unix Doma
 * ecdsa-sha2-nistp384
 * ecdsa-sha2-nistp521
 * ssh-rsa with 2048, 3072, 4096 or 8192 KeyLength
+* sk-ssh-ed25519@openssh.com (FIDO/security key)
+* sk-ecdsa-sha2-nistp256@openssh.com (FIDO/security key)
+
+### FIDO / security keys
+
+FIDO identities (`ssh-keygen -t ed25519-sk` / `-t ecdsa-sk`) held by the agent
+are offered to the server automatically. The agent drives the authenticator, so
+touch (and, for verify-required keys, the PIN) is prompted at sign time; the
+private key never leaves the hardware. These identities have no SSH.NET `Key`,
+so `SshAgentPrivateKey.Key` is `null` for them.
 
 ### RSA and legacy ssh-rsa
 

--- a/SshNet.Agent.Tests/CertificateTests.cs
+++ b/SshNet.Agent.Tests/CertificateTests.cs
@@ -42,7 +42,7 @@ namespace SshNet.Agent.Tests
             var algorithm = Assert.IsType<CertificateHostAlgorithm>(identity.HostKeyAlgorithms.First());
             Assert.Equal("ssh-ed25519-cert-v01@openssh.com", algorithm.Name);
             Assert.Equal(blob, algorithm.Data);
-            Assert.Equal("cert identity", identity.Key.Comment);
+            Assert.Equal("cert identity", identity.Key!.Comment);
         }
 
         [Fact]

--- a/SshNet.Agent.Tests/ProtocolEncodingTests.cs
+++ b/SshNet.Agent.Tests/ProtocolEncodingTests.cs
@@ -185,6 +185,45 @@ namespace SshNet.Agent.Tests
         }
 
         [Fact]
+        public void Sign_FidoKey_ReturnsTheAgentBlobVerbatim()
+        {
+            using var fake = new FakeAgent();
+            var blob = Wire.Cat(
+                Wire.Str("sk-ssh-ed25519@openssh.com"),
+                Wire.Str(new byte[32]),
+                Wire.Str("ssh:"));
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(blob), Wire.Str("fido key")));
+            var identity = Assert.Single(fake.CreateClient().RequestIdentities());
+            var algorithm = identity.HostKeyAlgorithms.First();
+            Assert.Equal("sk-ssh-ed25519@openssh.com", algorithm.Name);
+
+            // string algorithm, string signature, byte flags, uint32 counter
+            var skSignature = Wire.Cat(
+                Wire.Str("sk-ssh-ed25519@openssh.com"),
+                Wire.Str(new byte[] { 0xca, 0xfe, 0xba, 0xbe }),
+                new byte[] { 0x01 },        // SSH_SK_USER_PRESENCE_REQD
+                Wire.U32(42));              // signature counter
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentSignResponse },
+                Wire.Str(skSignature)));
+
+            var signature = algorithm.Sign(new byte[] { 1, 2, 3, 4 });
+
+            // the whole sk blob, flags and counter included, goes on the wire as-is
+            Assert.Equal(skSignature, signature);
+            fake.Requests.TryDequeue(out _); // request-identities
+            Assert.True(fake.Requests.TryDequeue(out var raw));
+            var request = new WireReader(raw!);
+            Assert.Equal(Ssh2AgentcSignRequest, request.Byte());
+            Assert.Equal(blob, request.Str());
+            request.Str(); // data
+            Assert.Equal(0u, request.U32()); // no sign flags for sk keys
+        }
+
+        [Fact]
         public void RemoveAllIdentities_SendsTheBareMessage()
         {
             using var fake = new FakeAgent();

--- a/SshNet.Agent.Tests/RequestIdentitiesTests.cs
+++ b/SshNet.Agent.Tests/RequestIdentitiesTests.cs
@@ -9,10 +9,9 @@ namespace SshNet.Agent.Tests
         private const byte Ssh2AgentIdentitiesAnswer = 12;
 
         [Fact]
-        public void UnsupportedKeyTypes_AreSkipped()
+        public void FidoKey_IsOfferedWithItsBlobAndName()
         {
             using var fake = new FakeAgent();
-            var ed25519Blob = TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen);
             // a FIDO key as held by any agent that served ssh-keygen -t ed25519-sk
             var skBlob = Wire.Cat(
                 Wire.Str("sk-ssh-ed25519@openssh.com"),
@@ -20,8 +19,27 @@ namespace SshNet.Agent.Tests
                 Wire.Str("ssh:"));
             fake.EnqueueResponse(Wire.Cat(
                 new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(skBlob), Wire.Str("fido key")));
+
+            var identity = Assert.Single(fake.CreateClient().RequestIdentities());
+
+            var algorithm = identity.HostKeyAlgorithms.First();
+            Assert.Equal("sk-ssh-ed25519@openssh.com", algorithm.Name);
+            Assert.Equal(skBlob, algorithm.Data);
+            Assert.Null(identity.Key); // no SSH.NET Key type for sk-* keys
+        }
+
+        [Fact]
+        public void UnknownKeyTypes_AreSkipped()
+        {
+            using var fake = new FakeAgent();
+            var ed25519Blob = TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen);
+            var unknownBlob = Wire.Cat(Wire.Str("ssh-something-new@openssh.com"), Wire.Str(new byte[8]));
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
                 Wire.U32(2),
-                Wire.Str(skBlob), Wire.Str("fido key"),
+                Wire.Str(unknownBlob), Wire.Str("mystery key"),
                 Wire.Str(ed25519Blob), Wire.Str("ed25519 key")));
 
             var identities = fake.CreateClient().RequestIdentities();
@@ -29,7 +47,7 @@ namespace SshNet.Agent.Tests
             var identity = Assert.Single(identities);
             var algorithm = (KeyHostAlgorithm)identity.HostKeyAlgorithms.First();
             Assert.Equal(ed25519Blob, algorithm.Data);
-            Assert.Equal("ed25519 key", algorithm.Key.Comment);
+            Assert.Equal("ed25519 key", algorithm.Key!.Comment);
         }
 
         [Fact]

--- a/SshNet.Agent/AgentMessage/RequestIdentities.cs
+++ b/SshNet.Agent/AgentMessage/RequestIdentities.cs
@@ -54,6 +54,10 @@ namespace SshNet.Agent.AgentMessage
                     case "ssh-ed25519":
                         key = new ED25519AgentKey(_agent, keyData);
                         break;
+                    case "sk-ecdsa-sha2-nistp256@openssh.com":
+                    case "sk-ssh-ed25519@openssh.com":
+                        keys.Add(new SshAgentPrivateKey(_agent, keyData, keyType));
+                        continue;
                     case "ssh-rsa-cert-v01@openssh.com":
                     case "ecdsa-sha2-nistp256-cert-v01@openssh.com":
                     case "ecdsa-sha2-nistp384-cert-v01@openssh.com":
@@ -64,9 +68,9 @@ namespace SshNet.Agent.AgentMessage
                         keys.Add(new SshAgentPrivateKey(_agent, certificate, keyData));
                         continue;
                     default:
-                        // an agent may also hold key types this library cannot use,
-                        // e.g. FIDO keys (sk-*); leave those to other clients
-                        // instead of failing the whole list
+                        // an agent may hold key types this library cannot use;
+                        // leave those to other clients instead of failing the
+                        // whole list
                         continue;
                 }
                 key.Comment = comment;

--- a/SshNet.Agent/AgentMessage/RequestSign.cs
+++ b/SshNet.Agent/AgentMessage/RequestSign.cs
@@ -9,12 +9,14 @@ namespace SshNet.Agent.AgentMessage
         private readonly IAgentKey _key;
         private readonly byte[] _data;
         private readonly uint _flags;
+        private readonly bool _rawSignature;
 
-        public RequestSign(IAgentKey key, byte[] data, uint flags = 0)
+        public RequestSign(IAgentKey key, byte[] data, uint flags = 0, bool rawSignature = false)
         {
             _key = key;
             _data = data;
             _flags = flags;
+            _rawSignature = rawSignature;
         }
 
         public void To(AgentWriter writer)
@@ -39,6 +41,12 @@ namespace SshNet.Agent.AgentMessage
                 throw new SshAgentFailureException($"The agent answered {answer} instead of SSH2_AGENT_SIGN_RESPONSE");
 
             var signatureData = reader.ReadStringAsBytes();
+
+            // sk (FIDO) signatures carry extra flags and a counter; the whole blob
+            // is already the wire format, so return it instead of unwrapping it
+            if (_rawSignature)
+                return signatureData;
+
             using var signatureStream = new MemoryStream(signatureData);
             using var signatureReader = new AgentReader(signatureStream);
 

--- a/SshNet.Agent/Keys/SkAgentHostAlgorithm.cs
+++ b/SshNet.Agent/Keys/SkAgentHostAlgorithm.cs
@@ -1,0 +1,38 @@
+using System;
+using Renci.SshNet.Security;
+
+namespace SshNet.Agent.Keys
+{
+    /// <summary>
+    /// A FIDO/security-key identity (sk-ecdsa-sha2-nistp256@openssh.com or
+    /// sk-ssh-ed25519@openssh.com). SSH.NET has no <see cref="Key"/> type for
+    /// these, so both the public-key blob and the signature (which carries the
+    /// sk flags and counter) come straight from the agent, unchanged.
+    /// </summary>
+    internal class SkAgentHostAlgorithm : HostAlgorithm, IAgentKey
+    {
+        private readonly byte[] _keyData;
+
+        public SshAgent Agent { get; }
+
+        public byte[] KeyData => _keyData;
+
+        public override byte[] Data => _keyData;
+
+        public SkAgentHostAlgorithm(SshAgent agent, string name, byte[] keyData) : base(name)
+        {
+            Agent = agent;
+            _keyData = keyData;
+        }
+
+        public override byte[] Sign(byte[] input)
+        {
+            return Agent.Sign(this, input, rawSignature: true);
+        }
+
+        public override bool VerifySignature(byte[] data, byte[] signature)
+        {
+            throw new NotSupportedException("Signature verification is done by the SSH server, not the agent.");
+        }
+    }
+}

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -50,7 +50,7 @@ namespace SshNet.Agent
 
         /// <summary>
         /// Lists the identities the agent holds, usable as SSH.NET private key
-        /// sources. Key types this library cannot use (e.g. sk-*) are skipped.
+        /// sources. Key types this library cannot use are skipped.
         /// </summary>
         public SshAgentPrivateKey[] RequestIdentities()
         {
@@ -119,9 +119,9 @@ namespace SshNet.Agent
             _ = Send(new AddIdentity(keyFile, lifetime, confirm));
         }
 
-        internal byte[] Sign(IAgentKey key, byte[] data, uint flags = 0)
+        internal byte[] Sign(IAgentKey key, byte[] data, uint flags = 0, bool rawSignature = false)
         {
-            var signature = Send(new RequestSign(key, data, flags));
+            var signature = Send(new RequestSign(key, data, flags, rawSignature));
             if (signature is null)
                 throw new SshAgentException("The agent did not return a signature");
             return (byte[])signature;

--- a/SshNet.Agent/SshAgentPrivateKey.cs
+++ b/SshNet.Agent/SshAgentPrivateKey.cs
@@ -18,8 +18,12 @@ namespace SshNet.Agent
         /// <summary>The host key algorithms this identity is offered with.</summary>
         public IReadOnlyCollection<HostAlgorithm> HostKeyAlgorithms => _hostAlgorithms;
 
-        /// <summary>The public key; for certificates the key embedded in the certificate.</summary>
-        public Key Key { get; }
+        /// <summary>
+        /// The public key; for certificates the key embedded in the certificate.
+        /// <see langword="null"/> for FIDO/security keys (sk-*), which have no
+        /// SSH.NET <see cref="Key"/> type.
+        /// </summary>
+        public Key? Key { get; }
 
         /// <summary>The identity of a plain key held by the agent.</summary>
         public SshAgentPrivateKey(SshAgent agent, Key key)
@@ -39,6 +43,16 @@ namespace SshNet.Agent
             }
 
             _hostAlgorithms.Add(new KeyHostAlgorithm(key.ToString(), key));
+        }
+
+        /// <summary>
+        /// The identity of a FIDO/security key held by the agent
+        /// (sk-ecdsa-sha2-nistp256@openssh.com or sk-ssh-ed25519@openssh.com).
+        /// </summary>
+        public SshAgentPrivateKey(SshAgent agent, byte[] keyData, string keyType)
+        {
+            Key = null; // no SSH.NET Key type for sk-* keys
+            _hostAlgorithms.Add(new SkAgentHostAlgorithm(agent, keyType, keyData));
         }
 
         /// <summary>


### PR DESCRIPTION
## What

Agents holding FIDO/security-key identities (`sk-ecdsa-sha2-nistp256@openssh.com`, `sk-ssh-ed25519@openssh.com`) were silently skipped by `RequestIdentities`. They are now offered to the server and can authenticate.

## How

SSH.NET has no `Key` type for `sk-*` keys, and their wire format differs from plain ecdsa/ed25519:

- the **public-key blob** carries an extra `application` field, and
- the **signature** carries a trailing `byte flags` + `uint32 counter`.

So rather than subclassing an SSH.NET `Key`, a small `SkAgentHostAlgorithm : HostAlgorithm` offers the agent's public-key blob as-is (`Data`) under the `sk-*` name, and `RequestSign` gains a raw-passthrough path that returns the agent's signature blob verbatim (flags and counter included) instead of unwrapping and re-wrapping it. Signing stays in the agent, so the authenticator handles touch/PIN and the private key never leaves the hardware.

`SshAgentPrivateKey.Key` is `null` for these identities, since there is no SSH.NET `Key` behind them.

## Tests

- `FidoKey_IsOfferedWithItsBlobAndName` — the sk identity is offered under its algorithm name with its blob, `Key` is null.
- `Sign_FidoKey_ReturnsTheAgentBlobVerbatim` — the sk signature (flags + counter) reaches the wire unchanged, and the sign request goes out with the key blob and no sign flags.
- `UnknownKeyTypes_AreSkipped` — genuinely unknown types are still skipped without failing the whole list.

All 40 non-Docker unit tests pass; build is warning-free.

## Not covered

- sk certificates (`sk-*-cert-v01@openssh.com`) — SSH.NET's `Certificate` can't parse them; they still fall through to the skip path.
- Adding a FIDO key to the agent (`AddIdentity`) — sk keys are enrolled against the hardware via `ssh-add -K`, not from a `PrivateKeyFile`.