### PR TITLE
Surface the identity comment on SshAgentPrivateKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ FIDO identities (`ssh-keygen -t ed25519-sk` / `-t ecdsa-sk`) held by the agent
 are offered to the server automatically. The agent drives the authenticator, so
 touch (and, for verify-required keys, the PIN) is prompted at sign time; the
 private key never leaves the hardware. These identities have no SSH.NET `Key`,
-so `SshAgentPrivateKey.Key` is `null` for them.
+so `SshAgentPrivateKey.Key` is `null` for them; their comment is still available
+via `SshAgentPrivateKey.Comment`, which every identity carries.
 
 ### RSA and legacy ssh-rsa
 

--- a/SshNet.Agent.Tests/CertificateTests.cs
+++ b/SshNet.Agent.Tests/CertificateTests.cs
@@ -43,6 +43,7 @@ namespace SshNet.Agent.Tests
             Assert.Equal("ssh-ed25519-cert-v01@openssh.com", algorithm.Name);
             Assert.Equal(blob, algorithm.Data);
             Assert.Equal("cert identity", identity.Key!.Comment);
+            Assert.Equal("cert identity", identity.Comment);
         }
 
         [Fact]

--- a/SshNet.Agent.Tests/RequestIdentitiesTests.cs
+++ b/SshNet.Agent.Tests/RequestIdentitiesTests.cs
@@ -28,6 +28,7 @@ namespace SshNet.Agent.Tests
             Assert.Equal("sk-ssh-ed25519@openssh.com", algorithm.Name);
             Assert.Equal(skBlob, algorithm.Data);
             Assert.Null(identity.Key); // no SSH.NET Key type for sk-* keys
+            Assert.Equal("fido key", identity.Comment); // ... but the comment is still surfaced
         }
 
         [Fact]
@@ -48,6 +49,7 @@ namespace SshNet.Agent.Tests
             var algorithm = (KeyHostAlgorithm)identity.HostKeyAlgorithms.First();
             Assert.Equal(ed25519Blob, algorithm.Data);
             Assert.Equal("ed25519 key", algorithm.Key!.Comment);
+            Assert.Equal("ed25519 key", identity.Comment);
         }
 
         [Fact]

--- a/SshNet.Agent/AgentMessage/RequestIdentities.cs
+++ b/SshNet.Agent/AgentMessage/RequestIdentities.cs
@@ -56,7 +56,7 @@ namespace SshNet.Agent.AgentMessage
                         break;
                     case "sk-ecdsa-sha2-nistp256@openssh.com":
                     case "sk-ssh-ed25519@openssh.com":
-                        keys.Add(new SshAgentPrivateKey(_agent, keyData, keyType));
+                        keys.Add(new SshAgentPrivateKey(_agent, keyData, keyType, comment));
                         continue;
                     case "ssh-rsa-cert-v01@openssh.com":
                     case "ecdsa-sha2-nistp256-cert-v01@openssh.com":

--- a/SshNet.Agent/SshAgentPrivateKey.cs
+++ b/SshNet.Agent/SshAgentPrivateKey.cs
@@ -25,10 +25,14 @@ namespace SshNet.Agent
         /// </summary>
         public Key? Key { get; }
 
+        /// <summary>The comment the agent lists the identity under; empty when it has none.</summary>
+        public string Comment { get; }
+
         /// <summary>The identity of a plain key held by the agent.</summary>
         public SshAgentPrivateKey(SshAgent agent, Key key)
         {
             Key = key;
+            Comment = key.Comment ?? "";
 
             if (Key is RsaAgentKey rsaKey)
             {
@@ -49,9 +53,10 @@ namespace SshNet.Agent
         /// The identity of a FIDO/security key held by the agent
         /// (sk-ecdsa-sha2-nistp256@openssh.com or sk-ssh-ed25519@openssh.com).
         /// </summary>
-        public SshAgentPrivateKey(SshAgent agent, byte[] keyData, string keyType)
+        public SshAgentPrivateKey(SshAgent agent, byte[] keyData, string keyType, string comment = "")
         {
             Key = null; // no SSH.NET Key type for sk-* keys
+            Comment = comment;
             _hostAlgorithms.Add(new SkAgentHostAlgorithm(agent, keyType, keyData));
         }
 
@@ -62,6 +67,7 @@ namespace SshNet.Agent
         public SshAgentPrivateKey(SshAgent agent, Certificate certificate, byte[] certificateData)
         {
             Key = certificate.Key;
+            Comment = certificate.Key.Comment ?? "";
 
             // signing echoes the whole certificate blob back to the agent
             var identity = new CertificateAgentIdentity(agent, certificateData);


### PR DESCRIPTION
## Problem

`RequestIdentities` reads the per-identity comment the agent returns, but it only survived for plain and certificate keys (tucked onto `Key.Comment`). For **FIDO/`sk-` identities the comment was read and thrown away**, and there was no uniform way to read a comment anyway — `Key` is `null` for FIDO keys, so there was nowhere to look.

## Change

Add `SshAgentPrivateKey.Comment`, populated for **every** identity kind:

- plain keys and certificates derive it from the key the agent listed (no constructor signature change);
- the FIDO constructor gains an optional `comment` parameter, and `RequestIdentities` now passes it through.

This lets callers select an identity by name (e.g. the comment `ssh-add` shows) regardless of key type — the natural way to pick among several agent keys.

## Tests

Extended the existing FakeAgent-based tests to assert `identity.Comment` for all three kinds: plain (`RequestIdentitiesTests`), FIDO (`RequestIdentitiesTests`), and certificate (`CertificateTests`). All pass.

Compatible addition: `Comment` is a new property and the only signature change is an optional trailing parameter on the FIDO constructor.