### PR TITLE
Prepare the 2024.2.0.4 release

### DIFF
--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -5,7 +5,7 @@
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Agent</PackageId>
-        <Version>2024.2.0.4-beta</Version>
+        <Version>2024.2.0.4</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to authenticate via OpenSSH Agent and PuTTY Pageant</Description>


### PR DESCRIPTION
Promotes `SshNet.Agent` to its first stable release since **2024.2.0.1**, finalizing the `2024.2.0.2/.3/.4-beta` line. Merging bumps `<Version>` to `2024.2.0.4`, which the NuGet workflow publishes and tags.

> Version must be **≥ 2024.2.0.4** to supersede the already-published `2024.2.0.4-beta` prerelease on NuGet (`2024.2.0.2/.3` would rank *below* it).

## Changelog since 2024.2.0.1

### Features
- FIDO / security-key (`sk-*`) signing — agent drives the authenticator (touch / PIN), private key stays in hardware
- OpenSSH certificate identities (`*-cert-v01@openssh.com`)
- Key constraints: lifetime (`ssh-add -t`) and confirm (`ssh-add -c`)
- Agent locking / unlocking (`ssh-add -x` / `-X`)
- Full async API (including constrained adds and lock/unlock)
- `SshAgentPrivateKey.Comment` surfaced for every identity, including FIDO keys
- Prefer Pageant's OpenSSH named pipe over WM_COPYDATA (real async I/O, no 8 KB message limit)

### Improvements
- Prefer RSA SHA-2 (`rsa-sha2-512`/`-256`); offer legacy `ssh-rsa` only on request
- Added `net8.0` target
- Skip unsupported key types when listing identities
- Typed exceptions instead of bare `System.Exception`
- Connect/read/write timeouts; Windows named-pipe transport fixes

### Packaging / CI / Docs
- NuGet trusted publishing (OIDC)
- Fully documented public API (missing docs fail the build)
- Migrated solution to `.slnx`; added Dependabot; modernized the sample (System.CommandLine)
- Protocol-level fake-agent unit tests + real-world tests (ssh-agent, Pageant, sshd); lowest-supported-SSH.NET CI leg