### PR TITLE
Bound the synchronous agent response length

### DIFF
--- a/SshNet.Agent.Tests/RequestIdentitiesTests.cs
+++ b/SshNet.Agent.Tests/RequestIdentitiesTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using Renci.SshNet.Security;
 using Xunit;
@@ -59,6 +60,17 @@ namespace SshNet.Agent.Tests
             fake.EnqueueResponse(Wire.Cat(new[] { Ssh2AgentIdentitiesAnswer }, Wire.U32(0)));
 
             Assert.Empty(fake.CreateClient().RequestIdentities());
+        }
+
+        [Fact]
+        public void OversizedResponse_IsRejected()
+        {
+            using var fake = new FakeAgent();
+            // a length prefix beyond OpenSSH's AGENT_MAX_MSGLEN (256 KiB) must be refused,
+            // not blindly allocated
+            fake.EnqueueResponse(new byte[256 * 1024 + 1]);
+
+            Assert.Throws<InvalidDataException>(() => fake.CreateClient().RequestIdentities());
         }
     }
 }

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -131,9 +131,12 @@ namespace SshNet.Agent
         {
             using var socketStream = new SshAgentSocketStream(_socketPath, _timeout);
             using var writer = new AgentWriter(socketStream);
-            using var reader = new AgentReader(socketStream);
-
             message.To(writer);
+
+            // read the whole framed response first, bounding its length like the async path
+            var response = ReadMessage(socketStream);
+            using var responseStream = new MemoryStream(response);
+            using var reader = new AgentReader(responseStream);
             return message.From(reader);
         }
 
@@ -240,6 +243,32 @@ namespace SshNet.Agent
             while (offset < buffer.Length)
             {
                 var read = await stream.ReadAsync(buffer, offset, buffer.Length - offset, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    throw new EndOfStreamException("The agent closed the connection mid-message");
+                offset += read;
+            }
+        }
+
+        /// <summary>Synchronous counterpart of <see cref="ReadMessageAsync"/>.</summary>
+        private static byte[] ReadMessage(Stream stream)
+        {
+            var header = new byte[4];
+            ReadExactly(stream, header, 0);
+            var length = (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3];
+            if (length < 1 || length > MaxMessageLength)
+                throw new InvalidDataException($"Invalid agent message length {length}");
+
+            var message = new byte[4 + length];
+            Buffer.BlockCopy(header, 0, message, 0, 4);
+            ReadExactly(stream, message, 4);
+            return message;
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int offset)
+        {
+            while (offset < buffer.Length)
+            {
+                var read = stream.Read(buffer, offset, buffer.Length - offset);
                 if (read == 0)
                     throw new EndOfStreamException("The agent closed the connection mid-message");
                 offset += read;


### PR DESCRIPTION
## Problem

The async receive path caps an agent response at OpenSSH's `AGENT_MAX_MSGLEN` (256 KiB) before allocating ([SshAgent.cs](SshNet.Agent/SshNet.Agent/SshAgent.cs) `ReadMessageAsync`). The **synchronous** path had no equivalent guard — it wrapped the socket stream directly and let each message read fields off the wire, so a malformed or malicious length prefix could drive an unbounded allocation.

## Fix

Make the sync path mirror the async one: read the whole framed response into a length-checked buffer first (`ReadMessage` / `ReadExactly`, the synchronous counterparts of the existing async helpers), then parse from that buffer. Central change in `Send` — no per-message edits. The Pageant WM_COPYDATA path is unaffected (it is already bounded by its in-memory transport).

## Tests

All existing FakeAgent-based sync tests pass unchanged (they drive this exact path), and a new `OversizedResponse_IsRejected` asserts a response beyond `AGENT_MAX_MSGLEN` throws `InvalidDataException` rather than being allocated.
