### PR TITLE
Add PKCS#11 smartcard key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ var agent = new SshAgent { IncludeLegacySshRsa = true };
 - Auth with OpenSSH Certificates
 - Adding Keys
 - Adding Keys with Constraints (lifetime, confirm)
+- Adding and Removing PKCS#11 / Smartcard Keys
 - Getting Keys
 - Removing Keys
 - Removing all Keys
@@ -164,6 +165,32 @@ var agent = new SshAgent();
 agent.Lock("passphrase");
 // agent.RequestIdentities() is empty now
 agent.Unlock("passphrase");
+```
+
+### PKCS#11 / Smartcard Keys
+
+Keys held on a PKCS#11 token can be added to and removed from the agent, like
+`ssh-add -s`/`ssh-add -e`. The agent loads the key through the PKCS#11 provider
+(a shared library path) and unlocks the token with the PIN; the private key
+never leaves the token.
+
+```csharp
+var agent = new SshAgent();
+
+// ssh-add -s /usr/lib/opensc-pkcs11.so
+agent.AddSmartcardIdentity("/usr/lib/opensc-pkcs11.so", "1234");
+
+var keys = agent.RequestIdentities();
+
+// ssh-add -e /usr/lib/opensc-pkcs11.so
+agent.RemoveSmartcardIdentity("/usr/lib/opensc-pkcs11.so");
+```
+
+Smartcard keys can be added with the same lifetime/confirm constraints as
+regular keys:
+
+```csharp
+agent.AddSmartcardIdentity("/usr/lib/opensc-pkcs11.so", "1234", TimeSpan.FromMinutes(10), confirm: true);
 ```
 
 ## Resharper Warning

--- a/SshNet.Agent.Tests/SmartcardKeyTests.cs
+++ b/SshNet.Agent.Tests/SmartcardKeyTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class SmartcardKeyTests
+    {
+        private const byte SshAgentcAddSmartcardKey = 20;
+        private const byte SshAgentcRemoveSmartcardKey = 21;
+        private const byte SshAgentcAddSmartcardKeyConstrained = 26;
+        private const byte ConstrainLifetime = 1;
+        private const byte ConstrainConfirm = 2;
+        private const byte SshAgentSuccess = 6;
+
+        [Fact]
+        public void AddSmartcardIdentity_SendsProviderAndPin()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            fake.CreateClient().AddSmartcardIdentity("/usr/lib/opensc-pkcs11.so", "1234");
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcAddSmartcardKey, request.Byte());
+            Assert.Equal("/usr/lib/opensc-pkcs11.so", request.Text());
+            Assert.Equal("1234", request.Text());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void AddSmartcardIdentity_WithConstraints_SendsTheConstrainedMessage()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            fake.CreateClient().AddSmartcardIdentity("provider.dll", "1234", TimeSpan.FromMinutes(10), confirm: true);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcAddSmartcardKeyConstrained, request.Byte());
+            Assert.Equal("provider.dll", request.Text());
+            Assert.Equal("1234", request.Text());
+            Assert.Equal(ConstrainLifetime, request.Byte());
+            Assert.Equal(600u, request.U32());
+            Assert.Equal(ConstrainConfirm, request.Byte());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void RemoveSmartcardIdentity_SendsProviderAndPin()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            fake.CreateClient().RemoveSmartcardIdentity("provider.dll");
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcRemoveSmartcardKey, request.Byte());
+            Assert.Equal("provider.dll", request.Text());
+            Assert.Equal("", request.Text());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public void AddSmartcardIdentity_WhenAgentFails_Throws()
+        {
+            using var fake = new FakeAgent();
+
+            Assert.Throws<SshAgentFailureException>(
+                () => fake.CreateClient().AddSmartcardIdentity("provider.dll", "1234"));
+        }
+
+        [Fact]
+        public async Task AddSmartcardIdentityAsync_WithConstraints_SendsTheSameMessageAsTheSyncApi()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            await fake.CreateClient().AddSmartcardIdentityAsync("provider.dll", "1234",
+                TimeSpan.FromMinutes(10), confirm: true, cancellationToken: TestContext.Current.CancellationToken);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcAddSmartcardKeyConstrained, request.Byte());
+            Assert.Equal("provider.dll", request.Text());
+            Assert.Equal("1234", request.Text());
+            Assert.Equal(ConstrainLifetime, request.Byte());
+            Assert.Equal(600u, request.U32());
+            Assert.Equal(ConstrainConfirm, request.Byte());
+            Assert.True(request.AtEnd);
+        }
+
+        [Fact]
+        public async Task RemoveSmartcardIdentityAsync_SendsProviderAndPin()
+        {
+            using var fake = new FakeAgent();
+            fake.EnqueueResponse(new[] { SshAgentSuccess });
+
+            await fake.CreateClient().RemoveSmartcardIdentityAsync("provider.dll",
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            var request = new WireReader(fake.SingleRequest());
+            Assert.Equal(SshAgentcRemoveSmartcardKey, request.Byte());
+            Assert.Equal("provider.dll", request.Text());
+            Assert.Equal("", request.Text());
+            Assert.True(request.AtEnd);
+        }
+    }
+}

--- a/SshNet.Agent/AgentMessage/AddSmartcardKey.cs
+++ b/SshNet.Agent/AgentMessage/AddSmartcardKey.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+
+namespace SshNet.Agent.AgentMessage
+{
+    internal class AddSmartcardKey : IAgentMessage
+    {
+        // draft-miller-ssh-agent, "Key Constraints"
+        private const byte ConstrainLifetime = 1;
+        private const byte ConstrainConfirm = 2;
+
+        private readonly string _providerId;
+        private readonly string _pin;
+        private readonly TimeSpan? _lifetime;
+        private readonly bool _confirm;
+
+        public AddSmartcardKey(string providerId, string pin, TimeSpan? lifetime = null, bool confirm = false)
+        {
+            _providerId = providerId;
+            _pin = pin;
+            _lifetime = lifetime;
+            _confirm = confirm;
+        }
+
+        public void To(AgentWriter writer)
+        {
+            using var keyStream = new MemoryStream();
+            using var keyWriter = new AgentWriter(keyStream);
+
+            keyWriter.EncodeString(_providerId);
+            keyWriter.EncodeString(_pin);
+
+            var messageType = AgentMessageType.SSH_AGENTC_ADD_SMARTCARD_KEY;
+            if (_lifetime is not null || _confirm)
+            {
+                messageType = AgentMessageType.SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED;
+                if (_lifetime is not null)
+                {
+                    keyWriter.Write(ConstrainLifetime);
+                    keyWriter.Write(Convert.ToUInt32(_lifetime.Value.TotalSeconds));
+                }
+                if (_confirm)
+                    keyWriter.Write(ConstrainConfirm);
+            }
+            var keyData = keyStream.ToArray();
+
+            writer.Write((uint)(1 + keyData.Length));
+            writer.Write((byte)messageType);
+            writer.Write(keyData);
+        }
+
+        public object? From(AgentReader reader)
+        {
+            _ = reader.ReadUInt32(); // msglen
+            var answer = (AgentMessageType)reader.ReadByte();
+            if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH_AGENT_SUCCESS");
+            return null;
+        }
+    }
+}

--- a/SshNet.Agent/AgentMessage/RemoveSmartcardKey.cs
+++ b/SshNet.Agent/AgentMessage/RemoveSmartcardKey.cs
@@ -1,0 +1,38 @@
+using System.IO;
+
+namespace SshNet.Agent.AgentMessage
+{
+    internal class RemoveSmartcardKey : IAgentMessage
+    {
+        private readonly string _providerId;
+        private readonly string _pin;
+
+        public RemoveSmartcardKey(string providerId, string pin)
+        {
+            _providerId = providerId;
+            _pin = pin;
+        }
+
+        public void To(AgentWriter writer)
+        {
+            using var keyStream = new MemoryStream();
+            using var keyWriter = new AgentWriter(keyStream);
+            keyWriter.EncodeString(_providerId);
+            keyWriter.EncodeString(_pin);
+            var keyData = keyStream.ToArray();
+
+            writer.Write((uint)(1 + keyData.Length));
+            writer.Write((byte)AgentMessageType.SSH_AGENTC_REMOVE_SMARTCARD_KEY);
+            writer.Write(keyData);
+        }
+
+        public object? From(AgentReader reader)
+        {
+            _ = reader.ReadUInt32(); // msglen
+            var answer = (AgentMessageType)reader.ReadByte();
+            if (answer != AgentMessageType.SSH_AGENT_SUCCESS)
+                throw new SshAgentFailureException($"The agent answered {answer} instead of SSH_AGENT_SUCCESS");
+            return null;
+        }
+    }
+}

--- a/SshNet.Agent/SshAgent.cs
+++ b/SshNet.Agent/SshAgent.cs
@@ -119,6 +119,33 @@ namespace SshNet.Agent
             _ = Send(new AddIdentity(keyFile, lifetime, confirm));
         }
 
+        /// <summary>
+        /// Adds a key held on a PKCS#11 token to the agent, like ssh-add -s. The
+        /// agent loads the key through the PKCS#11 provider (a shared library
+        /// path) and unlocks the token with the PIN; the private key stays on the
+        /// token.
+        /// </summary>
+        public void AddSmartcardIdentity(string pkcs11Provider, string pin)
+        {
+            _ = Send(new AddSmartcardKey(pkcs11Provider, pin));
+        }
+
+        /// <summary>
+        /// Adds a PKCS#11 token key with constraints, like ssh-add -s -t/-c: the
+        /// agent removes the key again after <paramref name="lifetime"/>, and with
+        /// <paramref name="confirm"/> it asks for confirmation on every use.
+        /// </summary>
+        public void AddSmartcardIdentity(string pkcs11Provider, string pin, TimeSpan? lifetime, bool confirm = false)
+        {
+            _ = Send(new AddSmartcardKey(pkcs11Provider, pin, lifetime, confirm));
+        }
+
+        /// <summary>Removes a PKCS#11 token key from the agent, like ssh-add -e.</summary>
+        public void RemoveSmartcardIdentity(string pkcs11Provider, string pin = "")
+        {
+            _ = Send(new RemoveSmartcardKey(pkcs11Provider, pin));
+        }
+
         internal byte[] Sign(IAgentKey key, byte[] data, uint flags = 0, bool rawSignature = false)
         {
             var signature = Send(new RequestSign(key, data, flags, rawSignature));
@@ -178,6 +205,24 @@ namespace SshNet.Agent
         public async Task AddIdentityAsync(IPrivateKeySource keyFile, TimeSpan? lifetime, bool confirm = false, CancellationToken cancellationToken = default)
         {
             _ = await SendAsync(new AddIdentity(keyFile, lifetime, confirm), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="AddSmartcardIdentity(string, string)"/>.</summary>
+        public async Task AddSmartcardIdentityAsync(string pkcs11Provider, string pin, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new AddSmartcardKey(pkcs11Provider, pin), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="AddSmartcardIdentity(string, string, TimeSpan?, bool)"/>.</summary>
+        public async Task AddSmartcardIdentityAsync(string pkcs11Provider, string pin, TimeSpan? lifetime, bool confirm = false, CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new AddSmartcardKey(pkcs11Provider, pin, lifetime, confirm), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Async variant of <see cref="RemoveSmartcardIdentity"/>.</summary>
+        public async Task RemoveSmartcardIdentityAsync(string pkcs11Provider, string pin = "", CancellationToken cancellationToken = default)
+        {
+            _ = await SendAsync(new RemoveSmartcardKey(pkcs11Provider, pin), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Async variant of <see cref="Lock"/>.</summary>


### PR DESCRIPTION
## Summary

Adds support for adding and removing PKCS#11 / smartcard keys through the agent, the equivalent of `ssh-add -s` and `ssh-add -e`. The agent loads the key through the given PKCS#11 provider (a shared library path) and unlocks the token with the PIN; the private key never leaves the token.

The three message types were already declared in `AgentMessageType` but had no implementation; this fills that gap.

## API

```csharp
void AddSmartcardIdentity(string pkcs11Provider, string pin);
void AddSmartcardIdentity(string pkcs11Provider, string pin, TimeSpan? lifetime, bool confirm = false);
void RemoveSmartcardIdentity(string pkcs11Provider, string pin = "");
```

Plus `...Async` variants taking an optional `CancellationToken`. Adding supports the same lifetime/confirm constraints as regular keys (`SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED`).

## Protocol

- `SSH_AGENTC_ADD_SMARTCARD_KEY` (20)
- `SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED` (26)
- `SSH_AGENTC_REMOVE_SMARTCARD_KEY` (21)

per draft-miller-ssh-agent.

## Tests

Four wire-level tests in `SmartcardKeyTests` against the in-process `FakeAgent`, covering the plain add, the constrained add (lifetime + confirm), remove, and the failure path. All target frameworks build; tests pass.
