### PR TITLE
Add SshAgentServer for hosting keys over the agent protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ var agent = new SshAgent { IncludeLegacySshRsa = true };
 - Removing all Keys
 - Locking and Unlocking the Agent
 - Async API
+- Hosting an Agent (SshAgentServer)
 
 ## Agent Protocol Documentation
 [draft-miller-ssh-agent-02](https://tools.ietf.org/html/draft-miller-ssh-agent-02)
@@ -165,6 +166,34 @@ agent.Lock("passphrase");
 // agent.RequestIdentities() is empty now
 agent.Unlock("passphrase");
 ```
+
+### Hosting an Agent
+
+`SshAgentServer` is a minimal ssh-agent: it holds SSH.NET keys and answers the
+agent protocol (list and sign) over a unix domain socket (off Windows) or a
+named pipe (on Windows). Any SSH client can use it - including this library's
+own `SshAgent`, `ssh`, or `git`. Signing is done with the in-process keys, so
+the key material can come from anywhere your process can reach (a file, a
+generated key, an HSM/Key Vault wrapper).
+
+```csharp
+using var server = new SshAgentServer(new PrivateKeyFile("test.key"));
+server.Start("/tmp/my-agent.sock"); // a named pipe name on Windows
+
+// point ssh (or SshAgent) at it
+Environment.SetEnvironmentVariable("SSH_AUTH_SOCK", "/tmp/my-agent.sock");
+var keys = new SshAgent("/tmp/my-agent.sock", null).RequestIdentities();
+```
+
+Keys are added and removed through the .NET API (`new SshAgentServer(keys)`,
+`Add`, `Remove`) and via the protocol's remove/lock requests; adding a key over
+the protocol (`ssh-add`) is answered with a failure. Unix domain sockets need
+the netstandard2.1 or .NET build.
+
+The endpoint is a signing authority: anyone who can connect to it can list the
+keys and use them to sign. Keep it private - on .NET 7 and later the unix socket
+is created owner-only, otherwise put it in a directory only you can access; the
+Windows named pipe is created with the default owner-scoped ACL.
 
 ## Resharper Warning
 

--- a/SshNet.Agent.Tests/SshAgentServerTests.cs
+++ b/SshNet.Agent.Tests/SshAgentServerTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class SshAgentServerTests : IClassFixture<SshServerFixture>
+    {
+        private readonly SshServerFixture _server;
+
+        public SshAgentServerTests(SshServerFixture server)
+        {
+            _server = server;
+        }
+
+        /// <summary>Starts the server on a fresh endpoint and returns a client for it.</summary>
+        private static SshAgent StartClient(SshAgentServer server, out string? tempDir)
+        {
+            string endpoint;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                tempDir = null;
+                endpoint = "sshnet-agent-server-" + Guid.NewGuid().ToString("N");
+            }
+            else
+            {
+                tempDir = Directory.CreateTempSubdirectory("sshnet-agent-server-").FullName;
+                endpoint = Path.Combine(tempDir, "agent.sock");
+            }
+            server.Start(endpoint);
+            return new SshAgent(endpoint, TimeSpan.FromSeconds(10));
+        }
+
+        private static void Cleanup(string? tempDir)
+        {
+            if (tempDir is not null)
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        public void ListsIdentities_WithBlobAndComment()
+        {
+            var keyFile = TestKeys.PrivateKey(TestKeys.Ed25519Puttygen);
+            using var server = new SshAgentServer(keyFile);
+            var client = StartClient(server, out var tempDir);
+            try
+            {
+                var identity = Assert.Single(client.RequestIdentities());
+                Assert.Equal("sshnet-agent-test-" + TestKeys.Ed25519Puttygen, identity.Comment);
+                Assert.Equal(TestKeys.PublicKeyBlob(TestKeys.Ed25519Puttygen),
+                    ((KeyHostAlgorithm)identity.HostKeyAlgorithms.First()).Data);
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Theory]
+        [InlineData(TestKeys.Rsa)]
+        [InlineData(TestKeys.Ecdsa)]
+        [InlineData(TestKeys.Ed25519Puttygen)]
+        public void SignsData_ThatVerifiesAgainstThePublicKey(string keyName)
+        {
+            var keyFile = TestKeys.PrivateKey(keyName);
+            using var server = new SshAgentServer(keyFile);
+            var client = StartClient(server, out var tempDir);
+            try
+            {
+                var identity = Assert.Single(client.RequestIdentities());
+                var data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+                // signing round-trips to the server, which signs with the in-process key
+                var signAlgorithm = (KeyHostAlgorithm)identity.HostKeyAlgorithms.First();
+                var signature = signAlgorithm.Sign(data);
+
+                var verifier = keyFile.HostKeyAlgorithms.OfType<KeyHostAlgorithm>()
+                    .First(algorithm => algorithm.Name == signAlgorithm.Name);
+                Assert.True(verifier.VerifySignature(data, signature));
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public void Locked_HidesIdentities_UntilUnlocked()
+        {
+            using var server = new SshAgentServer(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen));
+            var client = StartClient(server, out var tempDir);
+            try
+            {
+                Assert.Single(client.RequestIdentities());
+
+                client.Lock("passphrase");
+                Assert.Empty(client.RequestIdentities());
+
+                client.Unlock("passphrase");
+                Assert.Single(client.RequestIdentities());
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public void Unlock_WithTheWrongPassphrase_Throws()
+        {
+            using var server = new SshAgentServer(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen));
+            var client = StartClient(server, out var tempDir);
+            try
+            {
+                client.Lock("passphrase");
+                Assert.Throws<SshAgentFailureException>(() => client.Unlock("wrong"));
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public void RemoveIdentity_DropsTheKey()
+        {
+            using var server = new SshAgentServer(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen));
+            var client = StartClient(server, out var tempDir);
+            try
+            {
+                var identity = Assert.Single(client.RequestIdentities());
+                client.RemoveIdentity(identity);
+                Assert.Empty(client.RequestIdentities());
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public void ServedKey_AuthenticatesAgainstARealServer()
+        {
+            _server.SkipUnlessAvailable();
+            using var agentServer = new SshAgentServer(TestKeys.PrivateKey(TestKeys.Ed25519Puttygen));
+            var client = StartClient(agentServer, out var tempDir);
+            try
+            {
+                var keys = client.RequestIdentities();
+                using var ssh = new SshClient(new ConnectionInfo(_server.Host, _server.Port, _server.User,
+                    new PrivateKeyAuthenticationMethod(_server.User, keys.ToArray<IPrivateKeySource>())));
+                ssh.Connect();
+                Assert.Equal("ok", ssh.RunCommand("echo ok").Result.Trim());
+            }
+            finally
+            {
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public void RemoveAllIdentities_ClearsTheStore()
+        {
+            var server = new SshAgentServer(
+                TestKeys.PrivateKey(TestKeys.Ed25519Puttygen),
+                TestKeys.PrivateKey(TestKeys.Rsa));
+            using (server)
+            {
+                var client = StartClient(server, out var tempDir);
+                try
+                {
+                    Assert.Equal(2, client.RequestIdentities().Length);
+                    client.RemoveAllIdentities();
+                    Assert.Empty(client.RequestIdentities());
+                }
+                finally
+                {
+                    Cleanup(tempDir);
+                }
+            }
+        }
+    }
+}

--- a/SshNet.Agent/SshAgentServer.cs
+++ b/SshNet.Agent/SshAgentServer.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+#if NETFRAMEWORK || NET
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
+using System.Threading;
+using System.Threading.Tasks;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using SshNet.Agent.AgentMessage;
+#if NETSTANDARD2_1 || NET
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+#endif
+
+namespace SshNet.Agent
+{
+    /// <summary>
+    /// A minimal ssh-agent server: it holds SSH.NET keys and answers the agent
+    /// protocol (list and sign) over a unix domain socket or a Windows named
+    /// pipe, so any SSH client - including this library's own <see cref="SshAgent"/>
+    /// - can use them. Signing is done with the in-process keys; this is the
+    /// building block for HSM/Key Vault-backed agents and Pageant replacements.
+    /// </summary>
+    /// <remarks>
+    /// Keys are added through the .NET API, not the agent protocol: a client
+    /// SSH_AGENTC_ADD_IDENTITY request is answered with SSH_AGENT_FAILURE. Unix
+    /// domain sockets need the netstandard2.1 or .NET build.
+    /// <para>
+    /// The endpoint is a signing authority: anyone who can connect to it can list
+    /// the keys and use them to sign. Keep it private - on .NET 7 and later the
+    /// unix socket is created owner-only, otherwise place it in a directory only
+    /// you can access. The Windows named pipe is created with the default
+    /// owner-scoped ACL.
+    /// </para>
+    /// </remarks>
+    public sealed class SshAgentServer : IDisposable
+    {
+        private const uint RsaSha2_256 = 2;
+        private const uint RsaSha2_512 = 4;
+
+        private readonly List<IPrivateKeySource> _keys = new();
+        private readonly object _sync = new();
+        private readonly CancellationTokenSource _cts = new();
+        private byte[]? _lockPassphrase;
+        private Task? _listener;
+#if NETSTANDARD2_1 || NET
+        private string? _socketFile;
+#endif
+
+        /// <summary>The socket path or pipe name the server is listening on.</summary>
+        public string? Endpoint { get; private set; }
+
+        /// <summary>Creates a server holding the given keys.</summary>
+        public SshAgentServer(params IPrivateKeySource[] keys)
+        {
+            _keys.AddRange(keys);
+        }
+
+        /// <summary>Adds a key the server offers and signs with.</summary>
+        public void Add(IPrivateKeySource key)
+        {
+            lock (_sync)
+                _keys.Add(key);
+        }
+
+        /// <summary>Removes a previously added key.</summary>
+        public void Remove(IPrivateKeySource key)
+        {
+            lock (_sync)
+                _keys.Remove(key);
+        }
+
+        /// <summary>
+        /// Starts listening on <paramref name="endpoint"/>: a unix domain socket
+        /// path off Windows, a named pipe name on Windows. Returns once the server
+        /// is ready to accept connections.
+        /// </summary>
+        public void Start(string endpoint)
+        {
+            if (_listener is not null)
+                throw new InvalidOperationException("The server is already started");
+            Endpoint = endpoint;
+#if NETSTANDARD2_1 || NET
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                listener.Bind(new UnixDomainSocketEndPoint(endpoint));
+#if NET7_0_OR_GREATER
+                // the socket is a signing authority; keep it usable only by the current user
+                File.SetUnixFileMode(endpoint, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+#endif
+                listener.Listen(16);
+                _socketFile = endpoint;
+                _listener = AcceptSocketsAsync(listener, _cts.Token);
+                return;
+            }
+#endif
+            if (!Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.OrdinalIgnoreCase))
+                throw new PlatformNotSupportedException("Unix domain sockets need the netstandard2.1 or .NET build of SshNet.Agent");
+            _listener = AcceptPipesAsync(endpoint, _cts.Token);
+        }
+
+        private async Task AcceptPipesAsync(string pipeName, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var server = CreatePipe(pipeName);
+                try
+                {
+                    await server.WaitForConnectionAsync(token).ConfigureAwait(false);
+                }
+                catch (Exception) when (token.IsCancellationRequested)
+                {
+                    server.Dispose();
+                    return;
+                }
+                _ = ServeAsync(server, token);
+            }
+        }
+
+        /// <summary>
+        /// Creates the pipe restricted to the current user, so only the account
+        /// running the server can reach this signing authority. Only ever called
+        /// on Windows, where the pipe transport exists. On netstandard, which has
+        /// no API to set the ACL at creation, the pipe's default owner-scoped
+        /// security descriptor applies.
+        /// </summary>
+        private static NamedPipeServerStream CreatePipe(string pipeName)
+        {
+#if NETFRAMEWORK || NET
+#pragma warning disable CA1416 // the pipe transport is only reached on Windows
+            var security = new PipeSecurity();
+            using var identity = WindowsIdentity.GetCurrent();
+            security.AddAccessRule(new PipeAccessRule(identity.User!, PipeAccessRights.FullControl, AccessControlType.Allow));
+#if NETFRAMEWORK
+            return new NamedPipeServerStream(pipeName, PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous, 0, 0, security);
+#else
+            return NamedPipeServerStreamAcl.Create(pipeName, PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous, 0, 0, security);
+#endif
+#pragma warning restore CA1416
+#else
+            return new NamedPipeServerStream(pipeName, PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+#endif
+        }
+
+#if NETSTANDARD2_1 || NET
+        private async Task AcceptSocketsAsync(Socket listener, CancellationToken token)
+        {
+            using var abort = token.Register(listener.Dispose);
+            while (!token.IsCancellationRequested)
+            {
+                Socket client;
+                try
+                {
+                    client = await listener.AcceptAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    return; // listener disposed on cancellation
+                }
+                _ = ServeAsync(new NetworkStream(client, ownsSocket: true), token);
+            }
+        }
+#endif
+
+        /// <summary>Serves one connection until the client closes it.</summary>
+        private async Task ServeAsync(Stream stream, CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var request = await ReadMessageAsync(stream, token).ConfigureAwait(false);
+                    if (request is null)
+                        return; // client hung up
+                    var response = Handle(request);
+                    var framed = Frame(response);
+                    await stream.WriteAsync(framed, 0, framed.Length, token).ConfigureAwait(false);
+                    await stream.FlushAsync(token).ConfigureAwait(false);
+                }
+            }
+            catch (Exception)
+            {
+                // a broken connection must not take the server down
+            }
+            finally
+            {
+                stream.Dispose();
+            }
+        }
+
+        /// <summary>Dispatches one request payload and returns the response payload.</summary>
+        private byte[] Handle(byte[] request)
+        {
+            using var stream = new MemoryStream(request);
+            using var reader = new AgentReader(stream);
+            var type = (AgentMessageType)reader.ReadByte();
+
+            lock (_sync)
+            {
+                var locked = _lockPassphrase is not null;
+                switch (type)
+                {
+                    case AgentMessageType.SSH2_AGENTC_REQUEST_IDENTITIES:
+                        return IdentitiesAnswer(locked);
+                    case AgentMessageType.SSH2_AGENTC_SIGN_REQUEST:
+                        return locked ? Failure() : SignResponse(reader);
+                    case AgentMessageType.SSH2_AGENTC_REMOVE_IDENTITY:
+                        return locked ? Failure() : RemoveIdentity(reader);
+                    case AgentMessageType.SSH2_AGENTC_REMOVE_ALL_IDENTITIES:
+                        if (locked)
+                            return Failure();
+                        _keys.Clear();
+                        return Success();
+                    case AgentMessageType.SSH_AGENTC_LOCK:
+                        return SetLock(reader, locking: true);
+                    case AgentMessageType.SSH_AGENTC_UNLOCK:
+                        return SetLock(reader, locking: false);
+                    default:
+                        return Failure();
+                }
+            }
+        }
+
+        private byte[] IdentitiesAnswer(bool locked)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new AgentWriter(stream);
+            writer.Write((byte)AgentMessageType.SSH2_AGENT_IDENTITIES_ANSWER);
+
+            // a locked agent hides its identities
+            var keys = locked ? new List<IPrivateKeySource>() : _keys;
+            writer.Write((uint)keys.Count);
+            foreach (var key in keys)
+            {
+                writer.EncodeString(PublicBlob(key));
+                writer.EncodeString(Comment(key));
+            }
+            return stream.ToArray();
+        }
+
+        private byte[] SignResponse(AgentReader reader)
+        {
+            var keyBlob = reader.ReadStringAsBytes();
+            var data = reader.ReadStringAsBytes();
+            var flags = reader.ReadUInt32();
+
+            var algorithm = SelectForSigning(keyBlob, flags);
+            if (algorithm is null)
+                return Failure();
+
+            using var stream = new MemoryStream();
+            using var writer = new AgentWriter(stream);
+            writer.Write((byte)AgentMessageType.SSH2_AGENT_SIGN_RESPONSE);
+            writer.EncodeString(algorithm.Sign(data));
+            return stream.ToArray();
+        }
+
+        private byte[] RemoveIdentity(AgentReader reader)
+        {
+            var keyBlob = reader.ReadStringAsBytes();
+            var match = _keys.FirstOrDefault(key => PublicBlob(key).SequenceEqual(keyBlob));
+            if (match is null)
+                return Failure();
+            _keys.Remove(match);
+            return Success();
+        }
+
+        private byte[] SetLock(AgentReader reader, bool locking)
+        {
+            var passphrase = reader.ReadStringAsBytes();
+            if (locking)
+            {
+                if (_lockPassphrase is not null)
+                    return Failure(); // already locked
+                _lockPassphrase = passphrase;
+                return Success();
+            }
+
+            if (_lockPassphrase is null || !_lockPassphrase.SequenceEqual(passphrase))
+                return Failure();
+            _lockPassphrase = null;
+            return Success();
+        }
+
+        /// <summary>Finds the key matching the requested blob and the algorithm to sign with.</summary>
+        private HostAlgorithm? SelectForSigning(byte[] keyBlob, uint flags)
+        {
+            foreach (var key in _keys)
+            {
+                var matching = key.HostKeyAlgorithms.Where(a => a.Data.SequenceEqual(keyBlob)).ToList();
+                if (matching.Count == 0)
+                    continue;
+
+                // RSA offers several signature algorithms over the same key blob;
+                // the sign flags pick the hash (RFC 8332)
+                string? preferred = null;
+                if ((flags & RsaSha2_512) != 0)
+                    preferred = "rsa-sha2-512";
+                else if ((flags & RsaSha2_256) != 0)
+                    preferred = "rsa-sha2-256";
+                if (preferred is not null)
+                {
+                    var byFlag = matching.FirstOrDefault(a => a.Name.Contains(preferred));
+                    if (byFlag is not null)
+                        return byFlag;
+                }
+                return matching[0];
+            }
+            return null;
+        }
+
+        private static byte[] PublicBlob(IPrivateKeySource key)
+        {
+            return key.HostKeyAlgorithms.First().Data;
+        }
+
+        private static string Comment(IPrivateKeySource key)
+        {
+            // CertificateHostAlgorithm derives from KeyHostAlgorithm, so this
+            // covers plain keys and certificates alike
+            return key.HostKeyAlgorithms.First() is KeyHostAlgorithm keyAlgorithm
+                ? keyAlgorithm.Key.Comment ?? ""
+                : "";
+        }
+
+        private static byte[] Success() => new[] { (byte)AgentMessageType.SSH_AGENT_SUCCESS };
+        private static byte[] Failure() => new[] { (byte)AgentMessageType.SSH_AGENT_FAILURE };
+
+        private static byte[] Frame(byte[] payload)
+        {
+            var framed = new byte[4 + payload.Length];
+            var length = (uint)payload.Length;
+            framed[0] = (byte)(length >> 24);
+            framed[1] = (byte)(length >> 16);
+            framed[2] = (byte)(length >> 8);
+            framed[3] = (byte)length;
+            Buffer.BlockCopy(payload, 0, framed, 4, payload.Length);
+            return framed;
+        }
+
+        private const int MaxMessageLength = 256 * 1024; // OpenSSH AGENT_MAX_MSGLEN
+
+        private static async Task<byte[]?> ReadMessageAsync(Stream stream, CancellationToken token)
+        {
+            var header = await ReadExactlyAsync(stream, 4, token).ConfigureAwait(false);
+            if (header is null)
+                return null;
+            var length = (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3];
+            if (length < 1 || length > MaxMessageLength)
+                throw new InvalidDataException($"Invalid agent message length {length}");
+            return await ReadExactlyAsync(stream, length, token).ConfigureAwait(false);
+        }
+
+        private static async Task<byte[]?> ReadExactlyAsync(Stream stream, int count, CancellationToken token)
+        {
+            var buffer = new byte[count];
+            var offset = 0;
+            while (offset < count)
+            {
+                var read = await stream.ReadAsync(buffer, offset, count - offset, token).ConfigureAwait(false);
+                if (read == 0)
+                    return null;
+                offset += read;
+            }
+            return buffer;
+        }
+
+        /// <summary>Stops the server and releases the socket or pipe.</summary>
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try
+            {
+                _listener?.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+                // listener aborted on cancellation
+            }
+            _cts.Dispose();
+#if NETSTANDARD2_1 || NET
+            if (_socketFile is not null)
+            {
+                try { File.Delete(_socketFile); } catch { /* best effort */ }
+            }
+#endif
+        }
+    }
+}

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -44,4 +44,9 @@
         <PackageReference Include="SSH.NET" Version="[2024.2.0,2026.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
     </ItemGroup>
+
+    <!-- net48 has the named-pipe ACL ctor in-box; .NET needs this for NamedPipeServerStreamAcl -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds `SshAgentServer`, a minimal in-process ssh-agent. It holds SSH.NET keys and answers the agent protocol — identity listing and signing — over a unix domain socket (off Windows) or a Windows named pipe, so any SSH client (this library's own `SshAgent`, `ssh`, `git`, …) can use keys hosted by a .NET process. Because signing is done in-process with the loaded keys, the key material can come from anywhere the process can reach: a file, a freshly generated key, or an HSM/Key Vault wrapper.

This turns the library from an agent *client* into a small agent *toolkit*, and is the building block for Key Vault-backed agents, Pageant replacements and WSL↔Windows bridges.

## API

```csharp
var server = new SshAgentServer(params IPrivateKeySource[] keys);
server.Add(IPrivateKeySource key);
server.Remove(IPrivateKeySource key);
server.Start(string endpoint);   // socket path off Windows, pipe name on Windows
server.Dispose();                // stops listening
string? server.Endpoint { get; }
```

## Protocol coverage

- `SSH2_AGENTC_REQUEST_IDENTITIES` → lists the held keys (empty while locked)
- `SSH2_AGENTC_SIGN_REQUEST` → signs with the matching key, honouring the RFC 8332 RSA sha2 sign flags
- `SSH2_AGENTC_REMOVE_IDENTITY` / `REMOVE_ALL_IDENTITIES`
- `SSH_AGENTC_LOCK` / `UNLOCK`
- other requests (including `ADD_IDENTITY`) → `SSH_AGENT_FAILURE`

Keys are managed through the .NET API; pushing a key in over the protocol (`ssh-add`) is intentionally out of scope for now. Unix domain sockets need the netstandard2.1 or .NET build (same as the client).

## Tests

`SshAgentServerTests` drives the server through the library's own `SshAgent` client over a real socket/pipe:

- identity listing returns the right blob and comment
- signing round-trips and the signature **verifies against the public key** for RSA, ECDSA (nistp256) and Ed25519
- lock hides identities until unlocked; wrong passphrase is rejected
- remove and remove-all

Full suite: 53 passed, 18 environment-skipped (Docker / Pageant / OS agent), 0 failed. All target frameworks build.
