### PR TITLE
Document the SshNet.Keygen certificate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ using var client = new SshClient("ssh.foo.com", "root", keys);
 client.Connect();
 ```
 
+### Minting Certificates with SshNet.Keygen
+
+The certificate above can be produced in .NET with
+[SshNet.Keygen](https://github.com/darinkes/SshNet.Keygen), so the whole
+short-lived-certificate flow - mint, load into the agent, authenticate - stays
+in one process without shelling out to `ssh-keygen`:
+
+```csharp
+// mint a short-lived user certificate for test.key, signed by your CA
+var userKey = new PrivateKeyFile("test.key");
+var certificate = new SshCertificateBuilder(userKey)
+    .WithKeyId("root@example.com")
+    .WithPrincipal("root")
+    .WithValidity(DateTime.UtcNow, DateTime.UtcNow.AddHours(8))
+    .SignWith(new PrivateKeyFile("ca"));
+
+File.WriteAllText("test-cert.pub", certificate.ToOpenSshPublicFormat());
+
+// load the key together with the freshly minted certificate ...
+var agent = new SshAgent();
+agent.AddIdentity(new PrivateKeyFile("test.key", null, "test-cert.pub"));
+
+// ... and authenticate against a server that trusts the CA
+using var client = new SshClient("ssh.foo.com", "root", agent.RequestIdentities());
+client.Connect();
+```
+
+The same certificate can be served through an agent server, or used directly
+with SSH.NET without an agent.
+
 ### Async
 
 All agent operations are also available asynchronously and take an optional


### PR DESCRIPTION
## Summary

Documents the end-to-end short-lived-certificate flow that composes SshNet.Keygen and SshNet.Agent: mint a certificate in .NET with SshNet.Keygen's `SshCertificateBuilder`, load it into the agent alongside its key, and authenticate against a server that trusts the CA — all in-process, without shelling out to `ssh-keygen`.

This closes the loop between the two libraries: SshNet.Keygen can now sign certificates (see [SshNet.Keygen#55](https://github.com/darinkes/SshNet.Keygen/pull/55)), and SshNet.Agent already hosts and authenticates with certificate identities. The new README section shows them working together.

## Notes

- Documentation only — no code change. The two libraries ship as independent NuGet packages, so a compiling cross-repo sample would need a fragile relative project reference that breaks CI; the worked example in the README is the pragmatic deliverable. The composition is already covered transitively by tests on each side (SshNet.Keygen validates the minted certificates with `ssh-keygen -L`; SshNet.Agent's `CertificateTests` host and authenticate with certificate identities).
- The `SshAgentServer` cross-reference is worded to not depend on PR merge order.
