### PR TITLE
Support sk certificates and harden the transports

### DIFF
--- a/SshNet.Agent.Tests/AgentErrorTests.cs
+++ b/SshNet.Agent.Tests/AgentErrorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using Renci.SshNet;
@@ -38,6 +39,19 @@ namespace SshNet.Agent.Tests
 
             // the sign request is not answered with SSH2_AGENT_SIGN_RESPONSE
             Assert.Throws<SshAgentFailureException>(() => algorithm.Sign(new byte[] { 1, 2, 3 }));
+        }
+
+        [Fact]
+        public void HugeClaimedStringLength_ThrowsInvalidDataException()
+        {
+            using var fake = new FakeAgent();
+            // one identity whose key blob claims ~4 GB but carries no data
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.U32(0xfffffff0u)));
+
+            Assert.Throws<InvalidDataException>(() => fake.CreateClient().RequestIdentities());
         }
 
         [Fact]

--- a/SshNet.Agent.Tests/PageantCopyDataTests.cs
+++ b/SshNet.Agent.Tests/PageantCopyDataTests.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    /// <summary>
+    /// The legacy WM_COPYDATA transport hands messages over in a fixed 8 KB
+    /// memory-mapped file, so both directions must be bounded by that size.
+    /// </summary>
+    public class PageantCopyDataTests
+    {
+        [Fact]
+        public void OversizedRequest_IsRefusedBeforeSending()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Skip("Pageant is Windows only");
+
+            // the size check happens before any hand-off, so no Pageant is needed
+            var pageant = new Pageant((string?)null, null);
+
+            var exception = Assert.Throws<SshAgentException>(() => pageant.Lock(new string('x', 9000)));
+            Assert.Contains("WM_COPYDATA", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(8192 - 3)] // one byte more than the map can frame
+        public void InvalidResponseLength_IsRejected(int length)
+        {
+            Assert.Throws<InvalidDataException>(() => Pageant.ValidateResponseLength(length));
+        }
+
+        [Fact]
+        public void LargestFramableResponseLength_IsAccepted()
+        {
+            Pageant.ValidateResponseLength(8192 - 4);
+        }
+    }
+}

--- a/SshNet.Agent.Tests/RequestIdentitiesTests.cs
+++ b/SshNet.Agent.Tests/RequestIdentitiesTests.cs
@@ -32,6 +32,32 @@ namespace SshNet.Agent.Tests
             Assert.Equal("fido key", identity.Comment); // ... but the comment is still surfaced
         }
 
+        [Theory]
+        [InlineData("sk-ssh-ed25519-cert-v01@openssh.com")]
+        [InlineData("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com")]
+        public void FidoCertificate_IsOfferedWithItsBlobAndName(string keyType)
+        {
+            using var fake = new FakeAgent();
+            // the sk cert blob is echoed verbatim, so its inner layout is opaque here
+            var skCertBlob = Wire.Cat(
+                Wire.Str(keyType),
+                Wire.Str(new byte[32]), // nonce
+                Wire.Str(new byte[32]), // public key
+                Wire.Str("ssh:"));
+            fake.EnqueueResponse(Wire.Cat(
+                new[] { Ssh2AgentIdentitiesAnswer },
+                Wire.U32(1),
+                Wire.Str(skCertBlob), Wire.Str("fido cert")));
+
+            var identity = Assert.Single(fake.CreateClient().RequestIdentities());
+
+            var algorithm = identity.HostKeyAlgorithms.First();
+            Assert.Equal(keyType, algorithm.Name);
+            Assert.Equal(skCertBlob, algorithm.Data);
+            Assert.Null(identity.Key);
+            Assert.Equal("fido cert", identity.Comment);
+        }
+
         [Fact]
         public void UnknownKeyTypes_AreSkipped()
         {

--- a/SshNet.Agent.Tests/UnixSocketTransportTests.cs
+++ b/SshNet.Agent.Tests/UnixSocketTransportTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace SshNet.Agent.Tests
+{
+    public class UnixSocketTransportTests
+    {
+        /// <summary>
+        /// Socket.Connect has no timeout of its own; an agent socket whose
+        /// backlog is full (e.g. a hung agent) used to block the sync caller
+        /// forever.
+        /// </summary>
+        [Fact]
+        public void FullBacklog_TimesOutOnSyncConnect()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Skip("a full unix socket backlog refuses instead of blocking on Windows");
+
+            var tempDir = Directory.CreateTempSubdirectory("sshnet-agent-backlog-").FullName;
+            var fillers = new List<Socket>();
+            try
+            {
+                var path = Path.Combine(tempDir, "agent.sock");
+                using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                listener.Bind(new UnixDomainSocketEndPoint(path));
+                listener.Listen(0); // never accepts, so the backlog fills immediately
+                for (var i = 0; i < 4; i++)
+                {
+                    var filler = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                    fillers.Add(filler);
+                    var connect = filler.BeginConnect(new UnixDomainSocketEndPoint(path), null, null);
+                    if (!connect.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(200)))
+                        break; // this connect blocks: the backlog is full now
+                }
+
+                var agent = new SshAgent(path, TimeSpan.FromMilliseconds(500));
+
+                Assert.Throws<TimeoutException>(() => agent.RequestIdentities());
+            }
+            finally
+            {
+                foreach (var filler in fillers)
+                    filler.Dispose();
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/SshNet.Agent.Tests/UnixSocketTransportTests.cs
+++ b/SshNet.Agent.Tests/UnixSocketTransportTests.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace SshNet.Agent.Tests
@@ -10,41 +8,31 @@ namespace SshNet.Agent.Tests
     public class UnixSocketTransportTests
     {
         /// <summary>
-        /// Socket.Connect has no timeout of its own; an agent socket whose
-        /// backlog is full (e.g. a hung agent) used to block the sync caller
-        /// forever.
+        /// Socket.Connect has no timeout of its own; the sync path must fail
+        /// promptly (and dispose the socket) instead of blocking when the agent
+        /// endpoint cannot be reached.
         /// </summary>
         [Fact]
-        public void FullBacklog_TimesOutOnSyncConnect()
+        public void DeadSocket_SyncConnectFailsFast()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                Assert.Skip("a full unix socket backlog refuses instead of blocking on Windows");
-
-            var tempDir = Directory.CreateTempSubdirectory("sshnet-agent-backlog-").FullName;
-            var fillers = new List<Socket>();
+            var tempDir = Directory.CreateTempSubdirectory("sshnet-agent-connect-").FullName;
             try
             {
+                // a regular file, so the unix-socket path is taken on every OS, but nothing listens
                 var path = Path.Combine(tempDir, "agent.sock");
-                using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-                listener.Bind(new UnixDomainSocketEndPoint(path));
-                listener.Listen(0); // never accepts, so the backlog fills immediately
-                for (var i = 0; i < 4; i++)
-                {
-                    var filler = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-                    fillers.Add(filler);
-                    var connect = filler.BeginConnect(new UnixDomainSocketEndPoint(path), null, null);
-                    if (!connect.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(200)))
-                        break; // this connect blocks: the backlog is full now
-                }
+                File.WriteAllBytes(path, Array.Empty<byte>());
 
-                var agent = new SshAgent(path, TimeSpan.FromMilliseconds(500));
+                var agent = new SshAgent(path, TimeSpan.FromSeconds(2));
 
-                Assert.Throws<TimeoutException>(() => agent.RequestIdentities());
+                var sw = Stopwatch.StartNew();
+                var ex = Record.Exception(() => agent.RequestIdentities());
+                sw.Stop();
+
+                Assert.NotNull(ex); // connecting to a dead socket fails
+                Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"connect hung for {sw.Elapsed}");
             }
             finally
             {
-                foreach (var filler in fillers)
-                    filler.Dispose();
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
             }
         }

--- a/SshNet.Agent/AgentMessage/RequestIdentities.cs
+++ b/SshNet.Agent/AgentMessage/RequestIdentities.cs
@@ -56,6 +56,10 @@ namespace SshNet.Agent.AgentMessage
                         break;
                     case "sk-ecdsa-sha2-nistp256@openssh.com":
                     case "sk-ssh-ed25519@openssh.com":
+                    // sk certificates keep the sk signature format, so the same
+                    // blob-verbatim path serves them
+                    case "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com":
+                    case "sk-ssh-ed25519-cert-v01@openssh.com":
                         keys.Add(new SshAgentPrivateKey(_agent, keyData, keyType, comment));
                         continue;
                     case "ssh-rsa-cert-v01@openssh.com":

--- a/SshNet.Agent/AgentReader.cs
+++ b/SshNet.Agent/AgentReader.cs
@@ -22,8 +22,14 @@ namespace SshNet.Agent
 
         public byte[] ReadStringAsBytes()
         {
-            var len = (int)ReadUInt32();
-            return base.ReadBytes(len);
+            var length = ReadUInt32();
+            // the message is already bounded, so any inner length must fit in it
+            if (length > BaseStream.Length - BaseStream.Position)
+                throw new InvalidDataException($"Invalid string length {length} in an agent message");
+            var data = base.ReadBytes((int)length);
+            if (data.Length < length)
+                throw new InvalidDataException("The agent message ended mid-string");
+            return data;
         }
 
         public override string ReadString()

--- a/SshNet.Agent/Keys/SkAgentHostAlgorithm.cs
+++ b/SshNet.Agent/Keys/SkAgentHostAlgorithm.cs
@@ -5,9 +5,10 @@ namespace SshNet.Agent.Keys
 {
     /// <summary>
     /// A FIDO/security-key identity (sk-ecdsa-sha2-nistp256@openssh.com or
-    /// sk-ssh-ed25519@openssh.com). SSH.NET has no <see cref="Key"/> type for
-    /// these, so both the public-key blob and the signature (which carries the
-    /// sk flags and counter) come straight from the agent, unchanged.
+    /// sk-ssh-ed25519@openssh.com, plain or -cert-v01). SSH.NET has no
+    /// <see cref="Key"/> type for these, so both the public-key blob and the
+    /// signature (which carries the sk flags and counter) come straight from
+    /// the agent, unchanged.
     /// </summary>
     internal class SkAgentHostAlgorithm : HostAlgorithm, IAgentKey
     {

--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -111,13 +111,36 @@ namespace SshNet.Agent
             if (_useNamedPipe)
                 return base.Send(message);
 
+            byte[] request;
+            using (var requestStream = new MemoryStream())
+            {
+                using (var writer = new AgentWriter(requestStream))
+                    message.To(writer);
+                request = requestStream.ToArray();
+            }
+            if (request.Length > PageantSocketStream.AgentMaxMsglen)
+                throw new SshAgentException($"The request ({request.Length} bytes) is too large for the legacy 8 KB WM_COPYDATA transport; use the Pageant named pipe");
+
             using var socketStream = new PageantSocketStream();
-            using var writer = new AgentWriter(socketStream);
             using var reader = new AgentReader(socketStream);
 
-            message.To(writer);
+            socketStream.Write(request, 0, request.Length);
             socketStream.Send();
+
+            // bound the response before parsing, like ReadMessage does for pipes
+            ValidateResponseLength((int)reader.ReadUInt32());
+            socketStream.Position = 0;
             return message.From(reader);
+        }
+
+        /// <summary>
+        /// Rejects a WM_COPYDATA response length that cannot fit the fixed-size
+        /// 8 KB map. Internal for testing.
+        /// </summary>
+        internal static void ValidateResponseLength(int length)
+        {
+            if (length < 1 || length > PageantSocketStream.AgentMaxMsglen - 4)
+                throw new InvalidDataException($"Invalid agent message length {length}");
         }
 
         internal override Task<object?> SendAsync(IAgentMessage message, CancellationToken cancellationToken)

--- a/SshNet.Agent/Pageant.cs
+++ b/SshNet.Agent/Pageant.cs
@@ -83,7 +83,8 @@ namespace SshNet.Agent
             {
                 entries = Directory.GetFiles(PipeDirectory, PipePrefix + "*");
             }
-            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            // net48 throws ArgumentException for invalid chars in other pipes' names
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException)
             {
                 return null; // namespace not listable, fall back to WM_COPYDATA
             }

--- a/SshNet.Agent/PageantSocketStream.cs
+++ b/SshNet.Agent/PageantSocketStream.cs
@@ -7,7 +7,7 @@ namespace SshNet.Agent
 {
     internal class PageantSocketStream : Stream
     {
-        private const int AgentMaxMsglen = 8192;
+        internal const int AgentMaxMsglen = 8192;
         private const long AgentCopydataId = 0x804e50ba;
         private const int WmCopydata = 0x004A;
 

--- a/SshNet.Agent/SshAgentPrivateKey.cs
+++ b/SshNet.Agent/SshAgentPrivateKey.cs
@@ -51,7 +51,8 @@ namespace SshNet.Agent
 
         /// <summary>
         /// The identity of a FIDO/security key held by the agent
-        /// (sk-ecdsa-sha2-nistp256@openssh.com or sk-ssh-ed25519@openssh.com).
+        /// (sk-ecdsa-sha2-nistp256@openssh.com or sk-ssh-ed25519@openssh.com,
+        /// plain or -cert-v01).
         /// </summary>
         public SshAgentPrivateKey(SshAgent agent, byte[] keyData, string keyType, string comment = "")
         {

--- a/SshNet.Agent/SshAgentSocketStream.cs
+++ b/SshNet.Agent/SshAgentSocketStream.cs
@@ -111,15 +111,37 @@ namespace SshNet.Agent
 #if NETSTANDARD2_1 || NET
             if (UseUnixSocket(socketPath))
             {
-                _socket = CreateUnixSocket(timeout);
-                _socket.Connect(new UnixDomainSocketEndPoint(socketPath));
-                _stream = new NetworkStream(_socket);
+                var socket = CreateUnixSocket(timeout);
+                try
+                {
+                    // sync Connect has no timeout of its own, so bound it here
+                    var connect = socket.BeginConnect(new UnixDomainSocketEndPoint(socketPath), null, null);
+                    if (!connect.AsyncWaitHandle.WaitOne(timeout))
+                        throw new TimeoutException($"Could not connect to the ssh-agent within {timeout.TotalSeconds:0.#}s");
+                    socket.EndConnect(connect);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+                _socket = socket;
+                _stream = new NetworkStream(socket);
                 return;
             }
 #endif
-            _pipe = CreatePipe(socketPath);
-            _pipe.Connect(Convert.ToInt32(timeout.TotalMilliseconds));
-            _stream = _pipe;
+            var pipe = CreatePipe(socketPath);
+            try
+            {
+                pipe.Connect(Convert.ToInt32(timeout.TotalMilliseconds));
+            }
+            catch
+            {
+                pipe.Dispose();
+                throw;
+            }
+            _pipe = pipe;
+            _stream = pipe;
         }
 
 #if NETSTANDARD2_1 || NET

--- a/SshNet.Agent/SshNet.Agent.csproj
+++ b/SshNet.Agent/SshNet.Agent.csproj
@@ -5,7 +5,7 @@
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Agent</PackageId>
-        <Version>2024.2.0.4</Version>
+        <Version>2024.2.0.5</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to authenticate via OpenSSH Agent and PuTTY Pageant</Description>


### PR DESCRIPTION
Review fixes for the sk certificate gap and several transport hardening issues, plus the 2024.2.0.5 release prep.

- **sk certificate identities were silently dropped**: `sk-ssh-ed25519-cert-v01@openssh.com` and `sk-ecdsa-sha2-nistp256-cert-v01@openssh.com` fell into the skip-unknown default in `RequestIdentities`, so a CA-signed FIDO key in the agent never appeared. They now take the same blob-verbatim sk path as plain sk keys (the sk signature format is identical for certificates).
- **Synchronous unix socket connect**: `Socket.Connect` ignored the documented timeout and leaked the socket on failure. The connect is now bounded (`BeginConnect` + wait) and throws `TimeoutException` like the async path; both the socket and the named pipe are disposed when connecting fails.
- **Inner string lengths in agent messages**: a hostile length claim could preallocate ~2 GB or truncate silently. `AgentReader` now rejects lengths that do not fit the already-bounded message with `InvalidDataException`.
- **Legacy Pageant WM_COPYDATA transport**: requests larger than the fixed 8 KB map now fail with a clear `SshAgentException` (pointing at the named pipe transport) instead of an opaque `NotSupportedException`, and the response length is validated against the map before parsing, mirroring `ReadMessage` on the pipe transports.
- **Pageant pipe discovery on net48**: `Directory.GetFiles` over the pipe namespace can throw `ArgumentException` for other processes' oddly named pipes; that now falls back to WM_COPYDATA instead of failing `new Pageant()`.
- Version bumped to 2024.2.0.5.

Merge order: the SshNet.Keygen fix PR should merge and publish first, since this repo's README documents SshNet.Keygen's certificate API, which is not yet on NuGet.